### PR TITLE
feat(screen) add new <Screen> component

### DIFF
--- a/packages/core-md/src/components/animatedMaterialDesignTheme.ts
+++ b/packages/core-md/src/components/animatedMaterialDesignTheme.ts
@@ -11,6 +11,7 @@ import { appBarVariantsTheme } from './app-bar/theme';
 import { animatedButtonTheme } from './button/animatedTheme';
 import { listItemTheme } from './list-item/theme';
 import { listTheme } from './list/theme';
+import { screenTheme } from './screen/theme';
 import { surfaceTheme } from './surface/theme';
 import { rfxSvgVariantsTheme } from './svg/theme';
 import { rfxTextVariantsTheme } from './text/theme';
@@ -23,6 +24,7 @@ export const animatedMaterialDesignTheme: ComponentsTheme = {
   button: animatedButtonTheme,
   list: listTheme,
   listItem: listItemTheme,
+  screen: screenTheme,
   surface: surfaceTheme,
   svg: rfxSvgVariantsTheme,
   text: rfxTextVariantsTheme,

--- a/packages/core-md/src/components/index.ts
+++ b/packages/core-md/src/components/index.ts
@@ -13,6 +13,7 @@ export * from './createComponentsTheme';
 export * from './list';
 export * from './list-item';
 export * from './materialDesignTheme';
+export * from './screen';
 export * from './surface';
 export * from './svg';
 export * from './text';

--- a/packages/core-md/src/components/materialDesignTheme.ts
+++ b/packages/core-md/src/components/materialDesignTheme.ts
@@ -11,6 +11,7 @@ import { appBarVariantsTheme } from './app-bar/theme';
 import { buttonTheme } from './button/theme';
 import { listItemTheme } from './list-item/theme';
 import { listTheme } from './list/theme';
+import { screenTheme } from './screen/theme';
 import { surfaceTheme } from './surface/theme';
 import { rfxSvgVariantsTheme } from './svg/theme';
 import { rfxTextVariantsTheme } from './text/theme';
@@ -22,6 +23,7 @@ export const materialDesignTheme: ComponentsTheme = {
   button: buttonTheme,
   list: listTheme,
   listItem: listItemTheme,
+  screen: screenTheme,
   surface: surfaceTheme,
   svg: rfxSvgVariantsTheme,
   text: rfxTextVariantsTheme,

--- a/packages/core-md/src/components/screen/index.ts
+++ b/packages/core-md/src/components/screen/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export * from './theme';

--- a/packages/core-md/src/components/screen/theme.ts
+++ b/packages/core-md/src/components/screen/theme.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  SurfacePropsBase,
+  SurfaceTheme,
+  ViewStyleGetter,
+} from '@reflex-ui/core';
+
+import { getSurfaceContainerStyle } from '../surface/theme';
+
+export const getScreenContainerStyle: ViewStyleGetter<
+  SurfacePropsBase
+> = props => ({
+  ...getSurfaceContainerStyle(props),
+  borderRadius: 0,
+  flex: 1,
+  flexDirection: 'column',
+  flexWrap: 'nowrap',
+});
+
+export const screenTheme: SurfaceTheme = {
+  getStyle: getScreenContainerStyle,
+};

--- a/packages/core/src/components/ComponentsTheme.ts
+++ b/packages/core/src/components/ComponentsTheme.ts
@@ -18,6 +18,7 @@ export interface ComponentsTheme {
   readonly button?: ButtonVariantsTheme;
   readonly list?: SurfaceTheme;
   readonly listItem?: RfxViewTheme;
+  readonly screen?: SurfaceTheme;
   readonly surface?: SurfaceTheme;
   readonly svg?: RfxSvgVariantsTheme;
   readonly text?: RfxTextVariantsTheme;

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -30,6 +30,7 @@ export * from './SimpleComponentTheme';
 export * from './StyleGetter';
 export * from './StyleObj';
 export * from './StyleProps';
+export * from './screen';
 export * from './surface';
 export * from './svg';
 export * from './text';

--- a/packages/core/src/components/screen/Screen.tsx
+++ b/packages/core/src/components/screen/Screen.tsx
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useContext } from 'react';
+
+import { MissingComponentThemeError } from '../../errors';
+import { useOnLayout } from '../../responsiveness/useOnLayout';
+import { ComponentsTheme } from '../ComponentsTheme';
+import { ComponentsThemeContext } from '../ComponentsThemeContext';
+import { processComponent } from '../processComponent';
+import { processComponentProps } from '../processComponentProps';
+import { processThemeAndStyleProps } from '../processThemeAndStyleProps';
+import { SurfaceProps, SurfacePropsOptional } from '../surface/SurfaceProps';
+import { SurfaceTheme } from '../surface/SurfaceTheme';
+import { renderRfxViewComponent } from '../view/renderRfxViewComponent';
+import { useShouldProvideColor } from '../view/useShouldProvideColor';
+import { useDefaultScreenPropsBase } from './useDefaultScreenPropsBase';
+
+const getTheme = (
+  props: SurfacePropsOptional,
+  componentsTheme: ComponentsTheme,
+): SurfaceTheme => {
+  if (props.theme !== undefined && props.theme !== null) return props.theme;
+  if (componentsTheme.screen === undefined || componentsTheme.screen === null) {
+    throw new MissingComponentThemeError('<Screen>');
+  }
+  return componentsTheme.screen;
+};
+
+let Screen: React.ComponentType<SurfacePropsOptional> = (
+  props: SurfacePropsOptional,
+) => {
+  const componentsTheme = useContext(ComponentsThemeContext);
+  const theme = getTheme(props, componentsTheme);
+
+  let newProps: SurfaceProps = {
+    ...useDefaultScreenPropsBase(props),
+    theme,
+  };
+
+  newProps = { ...newProps, ...useOnLayout(newProps) };
+  newProps = processComponentProps(newProps);
+  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+
+  const shouldProvideColor = useShouldProvideColor(newProps);
+  return renderRfxViewComponent(newProps, shouldProvideColor);
+};
+
+Screen = processComponent<SurfacePropsOptional>(Screen, {
+  name: 'Screen',
+});
+
+export { Screen };

--- a/packages/core/src/components/screen/index.ts
+++ b/packages/core/src/components/screen/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export * from './Screen';
+export * from './useDefaultScreenPropsBase';

--- a/packages/core/src/components/screen/useDefaultScreenPropsBase.ts
+++ b/packages/core/src/components/screen/useDefaultScreenPropsBase.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useContext } from 'react';
+
+import { PaletteContext } from '../../color/PaletteContext';
+import {
+  SurfacePropsBase,
+  SurfacePropsBaseOptional,
+} from '../surface/SurfaceProps';
+// tslint:disable-next-line:max-line-length
+import { useDefaultSurfacePropsBase } from '../surface/useDefaultSurfacePropsBase';
+
+export const useDefaultScreenPropsBase = (
+  props: SurfacePropsBaseOptional,
+): SurfacePropsBase => {
+  const palette = useContext(PaletteContext);
+  const paletteColor = props.paletteColor || palette.screen;
+
+  return {
+    ...useDefaultSurfacePropsBase(props),
+    paletteColor,
+  };
+};


### PR DESCRIPTION
`<Screen>` component is a `<Surface>`, i.e. it uses `SurfaceProps` and `SurfaceTheme`, but it uses `Palette.screen` as default color, and has its own theme at `ComponentsTheme.screen`.