### PR TITLE
refactor(svg) upgrade react-native-svg to 9.4.0 and get rid of swgs

### DIFF
--- a/apps/core-showcase/package.json
+++ b/apps/core-showcase/package.json
@@ -20,13 +20,12 @@
     "react-dom": "16.8.4",
     "react-native": "0.59.1",
     "react-native-navigation": "2.15.0",
-    "react-native-svg": "9.3.5",
+    "react-native-svg": "9.4.0",
     "react-native-web": "0.11.1",
     "react-router-dom": "5.0.0",
     "react-spring": "5.6.14",
     "@reflex-ui/core": "0.1.0",
-    "@reflex-ui/core-md": "0.1.0",
-    "swgs": "3.3.0"
+    "@reflex-ui/core-md": "0.1.0"
   },
   "browserslist": [
     ">0.2%",

--- a/apps/core-showcase/src/screens/svg/PencilSvg.tsx
+++ b/apps/core-showcase/src/screens/svg/PencilSvg.tsx
@@ -9,8 +9,7 @@
  */
 
 import * as React from 'react';
-import { SvgProps } from 'react-native-svg';
-import { Path, Svg } from 'swgs';
+import { Path, Svg, SvgProps } from 'react-native-svg';
 
 export const PencilSvg = (props: SvgProps) => (
   <Svg

--- a/packages/icons-md/package.json
+++ b/packages/icons-md/package.json
@@ -49,9 +49,8 @@
     "react": ">=16.7.0",
     "react-dom": ">=16.7.0",
     "react-native": ">=0.58.3",
-    "react-native-svg": ">=9.0.0",
-    "react-native-web": ">=0.10.0",
-    "swgs": ">=3.3.0"
+    "react-native-svg": ">=9.4.0",
+    "react-native-web": ">=0.10.0"
   },
   "sideEffects": false
 }

--- a/packages/icons-md/src/action/AccessibilityIcon.tsx
+++ b/packages/icons-md/src/action/AccessibilityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AccessibleIcon.tsx
+++ b/packages/icons-md/src/action/AccessibleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AccountBalanceIcon.tsx
+++ b/packages/icons-md/src/action/AccountBalanceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AccountBalanceWalletIcon.tsx
+++ b/packages/icons-md/src/action/AccountBalanceWalletIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AccountBoxIcon.tsx
+++ b/packages/icons-md/src/action/AccountBoxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AccountCircleIcon.tsx
+++ b/packages/icons-md/src/action/AccountCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AddShoppingCartIcon.tsx
+++ b/packages/icons-md/src/action/AddShoppingCartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AlarmAddIcon.tsx
+++ b/packages/icons-md/src/action/AlarmAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AlarmIcon.tsx
+++ b/packages/icons-md/src/action/AlarmIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AlarmOffIcon.tsx
+++ b/packages/icons-md/src/action/AlarmOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AlarmOnIcon.tsx
+++ b/packages/icons-md/src/action/AlarmOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AllOutIcon.tsx
+++ b/packages/icons-md/src/action/AllOutIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AndroidIcon.tsx
+++ b/packages/icons-md/src/action/AndroidIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AnnouncementIcon.tsx
+++ b/packages/icons-md/src/action/AnnouncementIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AspectRatioIcon.tsx
+++ b/packages/icons-md/src/action/AspectRatioIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssessmentIcon.tsx
+++ b/packages/icons-md/src/action/AssessmentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssignmentIcon.tsx
+++ b/packages/icons-md/src/action/AssignmentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssignmentIndIcon.tsx
+++ b/packages/icons-md/src/action/AssignmentIndIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssignmentLateIcon.tsx
+++ b/packages/icons-md/src/action/AssignmentLateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssignmentReturnIcon.tsx
+++ b/packages/icons-md/src/action/AssignmentReturnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssignmentReturnedIcon.tsx
+++ b/packages/icons-md/src/action/AssignmentReturnedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AssignmentTurnedInIcon.tsx
+++ b/packages/icons-md/src/action/AssignmentTurnedInIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/AutorenewIcon.tsx
+++ b/packages/icons-md/src/action/AutorenewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/BackupIcon.tsx
+++ b/packages/icons-md/src/action/BackupIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/BookIcon.tsx
+++ b/packages/icons-md/src/action/BookIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/BookmarkBorderIcon.tsx
+++ b/packages/icons-md/src/action/BookmarkBorderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/BookmarkIcon.tsx
+++ b/packages/icons-md/src/action/BookmarkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/BugReportIcon.tsx
+++ b/packages/icons-md/src/action/BugReportIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/BuildIcon.tsx
+++ b/packages/icons-md/src/action/BuildIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CachedIcon.tsx
+++ b/packages/icons-md/src/action/CachedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CameraEnhanceIcon.tsx
+++ b/packages/icons-md/src/action/CameraEnhanceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CardGiftcardIcon.tsx
+++ b/packages/icons-md/src/action/CardGiftcardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CardMembershipIcon.tsx
+++ b/packages/icons-md/src/action/CardMembershipIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CardTravelIcon.tsx
+++ b/packages/icons-md/src/action/CardTravelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ChangeHistoryIcon.tsx
+++ b/packages/icons-md/src/action/ChangeHistoryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CheckCircleIcon.tsx
+++ b/packages/icons-md/src/action/CheckCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ChromeReaderModeIcon.tsx
+++ b/packages/icons-md/src/action/ChromeReaderModeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ClassIcon.tsx
+++ b/packages/icons-md/src/action/ClassIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CodeIcon.tsx
+++ b/packages/icons-md/src/action/CodeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CompareArrowsIcon.tsx
+++ b/packages/icons-md/src/action/CompareArrowsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CopyrightIcon.tsx
+++ b/packages/icons-md/src/action/CopyrightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/CreditCardIcon.tsx
+++ b/packages/icons-md/src/action/CreditCardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DashboardIcon.tsx
+++ b/packages/icons-md/src/action/DashboardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DateRangeIcon.tsx
+++ b/packages/icons-md/src/action/DateRangeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DeleteForeverIcon.tsx
+++ b/packages/icons-md/src/action/DeleteForeverIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DeleteIcon.tsx
+++ b/packages/icons-md/src/action/DeleteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DescriptionIcon.tsx
+++ b/packages/icons-md/src/action/DescriptionIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DnsIcon.tsx
+++ b/packages/icons-md/src/action/DnsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DoneAllIcon.tsx
+++ b/packages/icons-md/src/action/DoneAllIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DoneIcon.tsx
+++ b/packages/icons-md/src/action/DoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DonutLargeIcon.tsx
+++ b/packages/icons-md/src/action/DonutLargeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/DonutSmallIcon.tsx
+++ b/packages/icons-md/src/action/DonutSmallIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/EjectIcon.tsx
+++ b/packages/icons-md/src/action/EjectIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/EuroSymbolIcon.tsx
+++ b/packages/icons-md/src/action/EuroSymbolIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/EventIcon.tsx
+++ b/packages/icons-md/src/action/EventIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/EventSeatIcon.tsx
+++ b/packages/icons-md/src/action/EventSeatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ExitToAppIcon.tsx
+++ b/packages/icons-md/src/action/ExitToAppIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ExploreIcon.tsx
+++ b/packages/icons-md/src/action/ExploreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ExtensionIcon.tsx
+++ b/packages/icons-md/src/action/ExtensionIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FaceIcon.tsx
+++ b/packages/icons-md/src/action/FaceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FavoriteBorderIcon.tsx
+++ b/packages/icons-md/src/action/FavoriteBorderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FavoriteIcon.tsx
+++ b/packages/icons-md/src/action/FavoriteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FeedbackIcon.tsx
+++ b/packages/icons-md/src/action/FeedbackIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FindInPageIcon.tsx
+++ b/packages/icons-md/src/action/FindInPageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FindReplaceIcon.tsx
+++ b/packages/icons-md/src/action/FindReplaceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FingerprintIcon.tsx
+++ b/packages/icons-md/src/action/FingerprintIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FlightLandIcon.tsx
+++ b/packages/icons-md/src/action/FlightLandIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FlightTakeoffIcon.tsx
+++ b/packages/icons-md/src/action/FlightTakeoffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FlipToBackIcon.tsx
+++ b/packages/icons-md/src/action/FlipToBackIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/FlipToFrontIcon.tsx
+++ b/packages/icons-md/src/action/FlipToFrontIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/GTranslateIcon.tsx
+++ b/packages/icons-md/src/action/GTranslateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/GavelIcon.tsx
+++ b/packages/icons-md/src/action/GavelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/GetAppIcon.tsx
+++ b/packages/icons-md/src/action/GetAppIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/GifIcon.tsx
+++ b/packages/icons-md/src/action/GifIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/GradeIcon.tsx
+++ b/packages/icons-md/src/action/GradeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/GroupWorkIcon.tsx
+++ b/packages/icons-md/src/action/GroupWorkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HelpIcon.tsx
+++ b/packages/icons-md/src/action/HelpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HelpOutlineIcon.tsx
+++ b/packages/icons-md/src/action/HelpOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HighlightOffIcon.tsx
+++ b/packages/icons-md/src/action/HighlightOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HistoryIcon.tsx
+++ b/packages/icons-md/src/action/HistoryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HomeIcon.tsx
+++ b/packages/icons-md/src/action/HomeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HourglassEmptyIcon.tsx
+++ b/packages/icons-md/src/action/HourglassEmptyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HourglassFullIcon.tsx
+++ b/packages/icons-md/src/action/HourglassFullIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HttpIcon.tsx
+++ b/packages/icons-md/src/action/HttpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/HttpsIcon.tsx
+++ b/packages/icons-md/src/action/HttpsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ImportantDevicesIcon.tsx
+++ b/packages/icons-md/src/action/ImportantDevicesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/InfoIcon.tsx
+++ b/packages/icons-md/src/action/InfoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/InfoOutlineIcon.tsx
+++ b/packages/icons-md/src/action/InfoOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/InputIcon.tsx
+++ b/packages/icons-md/src/action/InputIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/InvertColorsIcon.tsx
+++ b/packages/icons-md/src/action/InvertColorsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LabelIcon.tsx
+++ b/packages/icons-md/src/action/LabelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LabelOutlineIcon.tsx
+++ b/packages/icons-md/src/action/LabelOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LanguageIcon.tsx
+++ b/packages/icons-md/src/action/LanguageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LaunchIcon.tsx
+++ b/packages/icons-md/src/action/LaunchIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LightbulbOutlineIcon.tsx
+++ b/packages/icons-md/src/action/LightbulbOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LineStyleIcon.tsx
+++ b/packages/icons-md/src/action/LineStyleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LineWeightIcon.tsx
+++ b/packages/icons-md/src/action/LineWeightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ListIcon.tsx
+++ b/packages/icons-md/src/action/ListIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LockIcon.tsx
+++ b/packages/icons-md/src/action/LockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LockOpenIcon.tsx
+++ b/packages/icons-md/src/action/LockOpenIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LockOutlineIcon.tsx
+++ b/packages/icons-md/src/action/LockOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/LoyaltyIcon.tsx
+++ b/packages/icons-md/src/action/LoyaltyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/MarkunreadMailboxIcon.tsx
+++ b/packages/icons-md/src/action/MarkunreadMailboxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/MotorcycleIcon.tsx
+++ b/packages/icons-md/src/action/MotorcycleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/NoteAddIcon.tsx
+++ b/packages/icons-md/src/action/NoteAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/OfflinePinIcon.tsx
+++ b/packages/icons-md/src/action/OfflinePinIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/OpacityIcon.tsx
+++ b/packages/icons-md/src/action/OpacityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/OpenInBrowserIcon.tsx
+++ b/packages/icons-md/src/action/OpenInBrowserIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/OpenInNewIcon.tsx
+++ b/packages/icons-md/src/action/OpenInNewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/OpenWithIcon.tsx
+++ b/packages/icons-md/src/action/OpenWithIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PageviewIcon.tsx
+++ b/packages/icons-md/src/action/PageviewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PanToolIcon.tsx
+++ b/packages/icons-md/src/action/PanToolIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PaymentIcon.tsx
+++ b/packages/icons-md/src/action/PaymentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermCameraMicIcon.tsx
+++ b/packages/icons-md/src/action/PermCameraMicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermContactCalendarIcon.tsx
+++ b/packages/icons-md/src/action/PermContactCalendarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermDataSettingIcon.tsx
+++ b/packages/icons-md/src/action/PermDataSettingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermDeviceInformationIcon.tsx
+++ b/packages/icons-md/src/action/PermDeviceInformationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermIdentityIcon.tsx
+++ b/packages/icons-md/src/action/PermIdentityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermMediaIcon.tsx
+++ b/packages/icons-md/src/action/PermMediaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermPhoneMsgIcon.tsx
+++ b/packages/icons-md/src/action/PermPhoneMsgIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PermScanWifiIcon.tsx
+++ b/packages/icons-md/src/action/PermScanWifiIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PetsIcon.tsx
+++ b/packages/icons-md/src/action/PetsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PictureInPictureAltIcon.tsx
+++ b/packages/icons-md/src/action/PictureInPictureAltIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PictureInPictureIcon.tsx
+++ b/packages/icons-md/src/action/PictureInPictureIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PlayForWorkIcon.tsx
+++ b/packages/icons-md/src/action/PlayForWorkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PolymerIcon.tsx
+++ b/packages/icons-md/src/action/PolymerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PowerSettingsNewIcon.tsx
+++ b/packages/icons-md/src/action/PowerSettingsNewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PregnantWomanIcon.tsx
+++ b/packages/icons-md/src/action/PregnantWomanIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/PrintIcon.tsx
+++ b/packages/icons-md/src/action/PrintIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/QueryBuilderIcon.tsx
+++ b/packages/icons-md/src/action/QueryBuilderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/QuestionAnswerIcon.tsx
+++ b/packages/icons-md/src/action/QuestionAnswerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ReceiptIcon.tsx
+++ b/packages/icons-md/src/action/ReceiptIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RecordVoiceOverIcon.tsx
+++ b/packages/icons-md/src/action/RecordVoiceOverIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RedeemIcon.tsx
+++ b/packages/icons-md/src/action/RedeemIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RemoveShoppingCartIcon.tsx
+++ b/packages/icons-md/src/action/RemoveShoppingCartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ReorderIcon.tsx
+++ b/packages/icons-md/src/action/ReorderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ReportProblemIcon.tsx
+++ b/packages/icons-md/src/action/ReportProblemIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RestoreIcon.tsx
+++ b/packages/icons-md/src/action/RestoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RestorePageIcon.tsx
+++ b/packages/icons-md/src/action/RestorePageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RoomIcon.tsx
+++ b/packages/icons-md/src/action/RoomIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/Rotation3dIcon.tsx
+++ b/packages/icons-md/src/action/Rotation3dIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RoundedCornerIcon.tsx
+++ b/packages/icons-md/src/action/RoundedCornerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/RowingIcon.tsx
+++ b/packages/icons-md/src/action/RowingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ScheduleIcon.tsx
+++ b/packages/icons-md/src/action/ScheduleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SearchIcon.tsx
+++ b/packages/icons-md/src/action/SearchIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsApplicationsIcon.tsx
+++ b/packages/icons-md/src/action/SettingsApplicationsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsBackupRestoreIcon.tsx
+++ b/packages/icons-md/src/action/SettingsBackupRestoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsBluetoothIcon.tsx
+++ b/packages/icons-md/src/action/SettingsBluetoothIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsBrightnessIcon.tsx
+++ b/packages/icons-md/src/action/SettingsBrightnessIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsCellIcon.tsx
+++ b/packages/icons-md/src/action/SettingsCellIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsEthernetIcon.tsx
+++ b/packages/icons-md/src/action/SettingsEthernetIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsIcon.tsx
+++ b/packages/icons-md/src/action/SettingsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsInputAntennaIcon.tsx
+++ b/packages/icons-md/src/action/SettingsInputAntennaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsInputComponentIcon.tsx
+++ b/packages/icons-md/src/action/SettingsInputComponentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsInputCompositeIcon.tsx
+++ b/packages/icons-md/src/action/SettingsInputCompositeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsInputHdmiIcon.tsx
+++ b/packages/icons-md/src/action/SettingsInputHdmiIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsInputSvideoIcon.tsx
+++ b/packages/icons-md/src/action/SettingsInputSvideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsOverscanIcon.tsx
+++ b/packages/icons-md/src/action/SettingsOverscanIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsPhoneIcon.tsx
+++ b/packages/icons-md/src/action/SettingsPhoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsPowerIcon.tsx
+++ b/packages/icons-md/src/action/SettingsPowerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsRemoteIcon.tsx
+++ b/packages/icons-md/src/action/SettingsRemoteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SettingsVoiceIcon.tsx
+++ b/packages/icons-md/src/action/SettingsVoiceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ShopIcon.tsx
+++ b/packages/icons-md/src/action/ShopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ShopTwoIcon.tsx
+++ b/packages/icons-md/src/action/ShopTwoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ShoppingBasketIcon.tsx
+++ b/packages/icons-md/src/action/ShoppingBasketIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ShoppingCartIcon.tsx
+++ b/packages/icons-md/src/action/ShoppingCartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SpeakerNotesIcon.tsx
+++ b/packages/icons-md/src/action/SpeakerNotesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SpeakerNotesOffIcon.tsx
+++ b/packages/icons-md/src/action/SpeakerNotesOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SpellcheckIcon.tsx
+++ b/packages/icons-md/src/action/SpellcheckIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/StarsIcon.tsx
+++ b/packages/icons-md/src/action/StarsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/StoreIcon.tsx
+++ b/packages/icons-md/src/action/StoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SubjectIcon.tsx
+++ b/packages/icons-md/src/action/SubjectIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SupervisorAccountIcon.tsx
+++ b/packages/icons-md/src/action/SupervisorAccountIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SwapHorizIcon.tsx
+++ b/packages/icons-md/src/action/SwapHorizIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SwapVertIcon.tsx
+++ b/packages/icons-md/src/action/SwapVertIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SwapVerticalCircleIcon.tsx
+++ b/packages/icons-md/src/action/SwapVerticalCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/SystemUpdateAltIcon.tsx
+++ b/packages/icons-md/src/action/SystemUpdateAltIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TabIcon.tsx
+++ b/packages/icons-md/src/action/TabIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TabUnselectedIcon.tsx
+++ b/packages/icons-md/src/action/TabUnselectedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TheatersIcon.tsx
+++ b/packages/icons-md/src/action/TheatersIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ThumbDownIcon.tsx
+++ b/packages/icons-md/src/action/ThumbDownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ThumbUpIcon.tsx
+++ b/packages/icons-md/src/action/ThumbUpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ThumbsUpDownIcon.tsx
+++ b/packages/icons-md/src/action/ThumbsUpDownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TimelineIcon.tsx
+++ b/packages/icons-md/src/action/TimelineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TocIcon.tsx
+++ b/packages/icons-md/src/action/TocIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TodayIcon.tsx
+++ b/packages/icons-md/src/action/TodayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TollIcon.tsx
+++ b/packages/icons-md/src/action/TollIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TouchAppIcon.tsx
+++ b/packages/icons-md/src/action/TouchAppIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TrackChangesIcon.tsx
+++ b/packages/icons-md/src/action/TrackChangesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TranslateIcon.tsx
+++ b/packages/icons-md/src/action/TranslateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TrendingDownIcon.tsx
+++ b/packages/icons-md/src/action/TrendingDownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TrendingFlatIcon.tsx
+++ b/packages/icons-md/src/action/TrendingFlatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TrendingUpIcon.tsx
+++ b/packages/icons-md/src/action/TrendingUpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TurnedInIcon.tsx
+++ b/packages/icons-md/src/action/TurnedInIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/TurnedInNotIcon.tsx
+++ b/packages/icons-md/src/action/TurnedInNotIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/UpdateIcon.tsx
+++ b/packages/icons-md/src/action/UpdateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/VerifiedUserIcon.tsx
+++ b/packages/icons-md/src/action/VerifiedUserIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewAgendaIcon.tsx
+++ b/packages/icons-md/src/action/ViewAgendaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewArrayIcon.tsx
+++ b/packages/icons-md/src/action/ViewArrayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewCarouselIcon.tsx
+++ b/packages/icons-md/src/action/ViewCarouselIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewColumnIcon.tsx
+++ b/packages/icons-md/src/action/ViewColumnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewDayIcon.tsx
+++ b/packages/icons-md/src/action/ViewDayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewHeadlineIcon.tsx
+++ b/packages/icons-md/src/action/ViewHeadlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewListIcon.tsx
+++ b/packages/icons-md/src/action/ViewListIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewModuleIcon.tsx
+++ b/packages/icons-md/src/action/ViewModuleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewQuiltIcon.tsx
+++ b/packages/icons-md/src/action/ViewQuiltIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewStreamIcon.tsx
+++ b/packages/icons-md/src/action/ViewStreamIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ViewWeekIcon.tsx
+++ b/packages/icons-md/src/action/ViewWeekIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/VisibilityIcon.tsx
+++ b/packages/icons-md/src/action/VisibilityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/VisibilityOffIcon.tsx
+++ b/packages/icons-md/src/action/VisibilityOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/WatchLaterIcon.tsx
+++ b/packages/icons-md/src/action/WatchLaterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/WorkIcon.tsx
+++ b/packages/icons-md/src/action/WorkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/YoutubeSearchedForIcon.tsx
+++ b/packages/icons-md/src/action/YoutubeSearchedForIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ZoomInIcon.tsx
+++ b/packages/icons-md/src/action/ZoomInIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/action/ZoomOutIcon.tsx
+++ b/packages/icons-md/src/action/ZoomOutIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/alert/AddAlertIcon.tsx
+++ b/packages/icons-md/src/alert/AddAlertIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/alert/ErrorIcon.tsx
+++ b/packages/icons-md/src/alert/ErrorIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/alert/ErrorOutlineIcon.tsx
+++ b/packages/icons-md/src/alert/ErrorOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/alert/WarningIcon.tsx
+++ b/packages/icons-md/src/alert/WarningIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/AddToQueueIcon.tsx
+++ b/packages/icons-md/src/av/AddToQueueIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/AirplayIcon.tsx
+++ b/packages/icons-md/src/av/AirplayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/AlbumIcon.tsx
+++ b/packages/icons-md/src/av/AlbumIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/ArtTrackIcon.tsx
+++ b/packages/icons-md/src/av/ArtTrackIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/AvTimerIcon.tsx
+++ b/packages/icons-md/src/av/AvTimerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/BrandingWatermarkIcon.tsx
+++ b/packages/icons-md/src/av/BrandingWatermarkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/CallToActionIcon.tsx
+++ b/packages/icons-md/src/av/CallToActionIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/ClosedCaptionIcon.tsx
+++ b/packages/icons-md/src/av/ClosedCaptionIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/EqualizerIcon.tsx
+++ b/packages/icons-md/src/av/EqualizerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/ExplicitIcon.tsx
+++ b/packages/icons-md/src/av/ExplicitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FastForwardIcon.tsx
+++ b/packages/icons-md/src/av/FastForwardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FastRewindIcon.tsx
+++ b/packages/icons-md/src/av/FastRewindIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FeaturedPlayListIcon.tsx
+++ b/packages/icons-md/src/av/FeaturedPlayListIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FeaturedVideoIcon.tsx
+++ b/packages/icons-md/src/av/FeaturedVideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FiberDvrIcon.tsx
+++ b/packages/icons-md/src/av/FiberDvrIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FiberManualRecordIcon.tsx
+++ b/packages/icons-md/src/av/FiberManualRecordIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle } from 'swgs';
+import { Svg, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FiberNewIcon.tsx
+++ b/packages/icons-md/src/av/FiberNewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FiberPinIcon.tsx
+++ b/packages/icons-md/src/av/FiberPinIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/FiberSmartRecordIcon.tsx
+++ b/packages/icons-md/src/av/FiberSmartRecordIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, G, Circle, Path } from 'swgs';
+import { Svg, G, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/Forward10Icon.tsx
+++ b/packages/icons-md/src/av/Forward10Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/Forward30Icon.tsx
+++ b/packages/icons-md/src/av/Forward30Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/Forward5Icon.tsx
+++ b/packages/icons-md/src/av/Forward5Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/GamesIcon.tsx
+++ b/packages/icons-md/src/av/GamesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/HdIcon.tsx
+++ b/packages/icons-md/src/av/HdIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/HearingIcon.tsx
+++ b/packages/icons-md/src/av/HearingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/HighQualityIcon.tsx
+++ b/packages/icons-md/src/av/HighQualityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/LibraryAddIcon.tsx
+++ b/packages/icons-md/src/av/LibraryAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/LibraryBooksIcon.tsx
+++ b/packages/icons-md/src/av/LibraryBooksIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/LibraryMusicIcon.tsx
+++ b/packages/icons-md/src/av/LibraryMusicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/LoopIcon.tsx
+++ b/packages/icons-md/src/av/LoopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/MicIcon.tsx
+++ b/packages/icons-md/src/av/MicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/MicNoneIcon.tsx
+++ b/packages/icons-md/src/av/MicNoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/MicOffIcon.tsx
+++ b/packages/icons-md/src/av/MicOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/MovieIcon.tsx
+++ b/packages/icons-md/src/av/MovieIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/MusicVideoIcon.tsx
+++ b/packages/icons-md/src/av/MusicVideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/NewReleasesIcon.tsx
+++ b/packages/icons-md/src/av/NewReleasesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/NotInterestedIcon.tsx
+++ b/packages/icons-md/src/av/NotInterestedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/NoteIcon.tsx
+++ b/packages/icons-md/src/av/NoteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PauseCircleFilledIcon.tsx
+++ b/packages/icons-md/src/av/PauseCircleFilledIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PauseCircleOutlineIcon.tsx
+++ b/packages/icons-md/src/av/PauseCircleOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PauseIcon.tsx
+++ b/packages/icons-md/src/av/PauseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PlayArrowIcon.tsx
+++ b/packages/icons-md/src/av/PlayArrowIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PlayCircleFilledIcon.tsx
+++ b/packages/icons-md/src/av/PlayCircleFilledIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PlayCircleOutlineIcon.tsx
+++ b/packages/icons-md/src/av/PlayCircleOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PlaylistAddCheckIcon.tsx
+++ b/packages/icons-md/src/av/PlaylistAddCheckIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PlaylistAddIcon.tsx
+++ b/packages/icons-md/src/av/PlaylistAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/PlaylistPlayIcon.tsx
+++ b/packages/icons-md/src/av/PlaylistPlayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/QueueIcon.tsx
+++ b/packages/icons-md/src/av/QueueIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/QueueMusicIcon.tsx
+++ b/packages/icons-md/src/av/QueueMusicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/QueuePlayNextIcon.tsx
+++ b/packages/icons-md/src/av/QueuePlayNextIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/RadioIcon.tsx
+++ b/packages/icons-md/src/av/RadioIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/RecentActorsIcon.tsx
+++ b/packages/icons-md/src/av/RecentActorsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/RemoveFromQueueIcon.tsx
+++ b/packages/icons-md/src/av/RemoveFromQueueIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/RepeatIcon.tsx
+++ b/packages/icons-md/src/av/RepeatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/RepeatOneIcon.tsx
+++ b/packages/icons-md/src/av/RepeatOneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/Replay10Icon.tsx
+++ b/packages/icons-md/src/av/Replay10Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/Replay30Icon.tsx
+++ b/packages/icons-md/src/av/Replay30Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/Replay5Icon.tsx
+++ b/packages/icons-md/src/av/Replay5Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/ReplayIcon.tsx
+++ b/packages/icons-md/src/av/ReplayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/ShuffleIcon.tsx
+++ b/packages/icons-md/src/av/ShuffleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SkipNextIcon.tsx
+++ b/packages/icons-md/src/av/SkipNextIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SkipPreviousIcon.tsx
+++ b/packages/icons-md/src/av/SkipPreviousIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SlowMotionVideoIcon.tsx
+++ b/packages/icons-md/src/av/SlowMotionVideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SnoozeIcon.tsx
+++ b/packages/icons-md/src/av/SnoozeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SortByAlphaIcon.tsx
+++ b/packages/icons-md/src/av/SortByAlphaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/StopIcon.tsx
+++ b/packages/icons-md/src/av/StopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SubscriptionsIcon.tsx
+++ b/packages/icons-md/src/av/SubscriptionsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SubtitlesIcon.tsx
+++ b/packages/icons-md/src/av/SubtitlesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/SurroundSoundIcon.tsx
+++ b/packages/icons-md/src/av/SurroundSoundIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VideoCallIcon.tsx
+++ b/packages/icons-md/src/av/VideoCallIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VideoLabelIcon.tsx
+++ b/packages/icons-md/src/av/VideoLabelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VideoLibraryIcon.tsx
+++ b/packages/icons-md/src/av/VideoLibraryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VideocamIcon.tsx
+++ b/packages/icons-md/src/av/VideocamIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VideocamOffIcon.tsx
+++ b/packages/icons-md/src/av/VideocamOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VolumeDownIcon.tsx
+++ b/packages/icons-md/src/av/VolumeDownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VolumeMuteIcon.tsx
+++ b/packages/icons-md/src/av/VolumeMuteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VolumeOffIcon.tsx
+++ b/packages/icons-md/src/av/VolumeOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/VolumeUpIcon.tsx
+++ b/packages/icons-md/src/av/VolumeUpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/WebAssetIcon.tsx
+++ b/packages/icons-md/src/av/WebAssetIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/av/WebIcon.tsx
+++ b/packages/icons-md/src/av/WebIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/BusinessIcon.tsx
+++ b/packages/icons-md/src/communication/BusinessIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallEndIcon.tsx
+++ b/packages/icons-md/src/communication/CallEndIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallIcon.tsx
+++ b/packages/icons-md/src/communication/CallIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallMadeIcon.tsx
+++ b/packages/icons-md/src/communication/CallMadeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallMergeIcon.tsx
+++ b/packages/icons-md/src/communication/CallMergeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallMissedIcon.tsx
+++ b/packages/icons-md/src/communication/CallMissedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallMissedOutgoingIcon.tsx
+++ b/packages/icons-md/src/communication/CallMissedOutgoingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallReceivedIcon.tsx
+++ b/packages/icons-md/src/communication/CallReceivedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CallSplitIcon.tsx
+++ b/packages/icons-md/src/communication/CallSplitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ChatBubbleIcon.tsx
+++ b/packages/icons-md/src/communication/ChatBubbleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ChatBubbleOutlineIcon.tsx
+++ b/packages/icons-md/src/communication/ChatBubbleOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ChatIcon.tsx
+++ b/packages/icons-md/src/communication/ChatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ClearAllIcon.tsx
+++ b/packages/icons-md/src/communication/ClearAllIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/CommentIcon.tsx
+++ b/packages/icons-md/src/communication/CommentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ContactMailIcon.tsx
+++ b/packages/icons-md/src/communication/ContactMailIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ContactPhoneIcon.tsx
+++ b/packages/icons-md/src/communication/ContactPhoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ContactsIcon.tsx
+++ b/packages/icons-md/src/communication/ContactsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/DialerSipIcon.tsx
+++ b/packages/icons-md/src/communication/DialerSipIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/DialpadIcon.tsx
+++ b/packages/icons-md/src/communication/DialpadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/EmailIcon.tsx
+++ b/packages/icons-md/src/communication/EmailIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ForumIcon.tsx
+++ b/packages/icons-md/src/communication/ForumIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ImportContactsIcon.tsx
+++ b/packages/icons-md/src/communication/ImportContactsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ImportExportIcon.tsx
+++ b/packages/icons-md/src/communication/ImportExportIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/InvertColorsOffIcon.tsx
+++ b/packages/icons-md/src/communication/InvertColorsOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/LiveHelpIcon.tsx
+++ b/packages/icons-md/src/communication/LiveHelpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/LocationOffIcon.tsx
+++ b/packages/icons-md/src/communication/LocationOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/LocationOnIcon.tsx
+++ b/packages/icons-md/src/communication/LocationOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/MailOutlineIcon.tsx
+++ b/packages/icons-md/src/communication/MailOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/MessageIcon.tsx
+++ b/packages/icons-md/src/communication/MessageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/NoSimIcon.tsx
+++ b/packages/icons-md/src/communication/NoSimIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PhoneIcon.tsx
+++ b/packages/icons-md/src/communication/PhoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PhonelinkEraseIcon.tsx
+++ b/packages/icons-md/src/communication/PhonelinkEraseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PhonelinkLockIcon.tsx
+++ b/packages/icons-md/src/communication/PhonelinkLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PhonelinkRingIcon.tsx
+++ b/packages/icons-md/src/communication/PhonelinkRingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PhonelinkSetupIcon.tsx
+++ b/packages/icons-md/src/communication/PhonelinkSetupIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PortableWifiOffIcon.tsx
+++ b/packages/icons-md/src/communication/PortableWifiOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/PresentToAllIcon.tsx
+++ b/packages/icons-md/src/communication/PresentToAllIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/RingVolumeIcon.tsx
+++ b/packages/icons-md/src/communication/RingVolumeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/RssFeedIcon.tsx
+++ b/packages/icons-md/src/communication/RssFeedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/ScreenShareIcon.tsx
+++ b/packages/icons-md/src/communication/ScreenShareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/SpeakerPhoneIcon.tsx
+++ b/packages/icons-md/src/communication/SpeakerPhoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/StayCurrentLandscapeIcon.tsx
+++ b/packages/icons-md/src/communication/StayCurrentLandscapeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/StayCurrentPortraitIcon.tsx
+++ b/packages/icons-md/src/communication/StayCurrentPortraitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/StayPrimaryLandscapeIcon.tsx
+++ b/packages/icons-md/src/communication/StayPrimaryLandscapeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/StayPrimaryPortraitIcon.tsx
+++ b/packages/icons-md/src/communication/StayPrimaryPortraitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/StopScreenShareIcon.tsx
+++ b/packages/icons-md/src/communication/StopScreenShareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/SwapCallsIcon.tsx
+++ b/packages/icons-md/src/communication/SwapCallsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/TextsmsIcon.tsx
+++ b/packages/icons-md/src/communication/TextsmsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/VoicemailIcon.tsx
+++ b/packages/icons-md/src/communication/VoicemailIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/communication/VpnKeyIcon.tsx
+++ b/packages/icons-md/src/communication/VpnKeyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/AddBoxIcon.tsx
+++ b/packages/icons-md/src/content/AddBoxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/AddCircleIcon.tsx
+++ b/packages/icons-md/src/content/AddCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/AddCircleOutlineIcon.tsx
+++ b/packages/icons-md/src/content/AddCircleOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/AddIcon.tsx
+++ b/packages/icons-md/src/content/AddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ArchiveIcon.tsx
+++ b/packages/icons-md/src/content/ArchiveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/BackspaceIcon.tsx
+++ b/packages/icons-md/src/content/BackspaceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/BlockIcon.tsx
+++ b/packages/icons-md/src/content/BlockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ClearIcon.tsx
+++ b/packages/icons-md/src/content/ClearIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ContentCopyIcon.tsx
+++ b/packages/icons-md/src/content/ContentCopyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ContentCutIcon.tsx
+++ b/packages/icons-md/src/content/ContentCutIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ContentPasteIcon.tsx
+++ b/packages/icons-md/src/content/ContentPasteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/CreateIcon.tsx
+++ b/packages/icons-md/src/content/CreateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/DeleteSweepIcon.tsx
+++ b/packages/icons-md/src/content/DeleteSweepIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/DraftsIcon.tsx
+++ b/packages/icons-md/src/content/DraftsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/FilterListIcon.tsx
+++ b/packages/icons-md/src/content/FilterListIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/FlagIcon.tsx
+++ b/packages/icons-md/src/content/FlagIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/FontDownloadIcon.tsx
+++ b/packages/icons-md/src/content/FontDownloadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ForwardIcon.tsx
+++ b/packages/icons-md/src/content/ForwardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/GestureIcon.tsx
+++ b/packages/icons-md/src/content/GestureIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/InboxIcon.tsx
+++ b/packages/icons-md/src/content/InboxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/LinkIcon.tsx
+++ b/packages/icons-md/src/content/LinkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/LowPriorityIcon.tsx
+++ b/packages/icons-md/src/content/LowPriorityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/MailIcon.tsx
+++ b/packages/icons-md/src/content/MailIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/MarkunreadIcon.tsx
+++ b/packages/icons-md/src/content/MarkunreadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/MoveToInboxIcon.tsx
+++ b/packages/icons-md/src/content/MoveToInboxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/NextWeekIcon.tsx
+++ b/packages/icons-md/src/content/NextWeekIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/RedoIcon.tsx
+++ b/packages/icons-md/src/content/RedoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/RemoveCircleIcon.tsx
+++ b/packages/icons-md/src/content/RemoveCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/RemoveCircleOutlineIcon.tsx
+++ b/packages/icons-md/src/content/RemoveCircleOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/RemoveIcon.tsx
+++ b/packages/icons-md/src/content/RemoveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ReplyAllIcon.tsx
+++ b/packages/icons-md/src/content/ReplyAllIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ReplyIcon.tsx
+++ b/packages/icons-md/src/content/ReplyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/ReportIcon.tsx
+++ b/packages/icons-md/src/content/ReportIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/SaveIcon.tsx
+++ b/packages/icons-md/src/content/SaveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/SelectAllIcon.tsx
+++ b/packages/icons-md/src/content/SelectAllIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/SendIcon.tsx
+++ b/packages/icons-md/src/content/SendIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/SortIcon.tsx
+++ b/packages/icons-md/src/content/SortIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/TextFormatIcon.tsx
+++ b/packages/icons-md/src/content/TextFormatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/UnarchiveIcon.tsx
+++ b/packages/icons-md/src/content/UnarchiveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/UndoIcon.tsx
+++ b/packages/icons-md/src/content/UndoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/content/WeekendIcon.tsx
+++ b/packages/icons-md/src/content/WeekendIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/AccessAlarmIcon.tsx
+++ b/packages/icons-md/src/device/AccessAlarmIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/AccessAlarmsIcon.tsx
+++ b/packages/icons-md/src/device/AccessAlarmsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/AccessTimeIcon.tsx
+++ b/packages/icons-md/src/device/AccessTimeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/AddAlarmIcon.tsx
+++ b/packages/icons-md/src/device/AddAlarmIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/AirplanemodeActiveIcon.tsx
+++ b/packages/icons-md/src/device/AirplanemodeActiveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/AirplanemodeInactiveIcon.tsx
+++ b/packages/icons-md/src/device/AirplanemodeInactiveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/Battery20Icon.tsx
+++ b/packages/icons-md/src/device/Battery20Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/Battery30Icon.tsx
+++ b/packages/icons-md/src/device/Battery30Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/Battery50Icon.tsx
+++ b/packages/icons-md/src/device/Battery50Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/Battery60Icon.tsx
+++ b/packages/icons-md/src/device/Battery60Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/Battery80Icon.tsx
+++ b/packages/icons-md/src/device/Battery80Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/Battery90Icon.tsx
+++ b/packages/icons-md/src/device/Battery90Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryAlertIcon.tsx
+++ b/packages/icons-md/src/device/BatteryAlertIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryCharging20Icon.tsx
+++ b/packages/icons-md/src/device/BatteryCharging20Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryCharging30Icon.tsx
+++ b/packages/icons-md/src/device/BatteryCharging30Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryCharging50Icon.tsx
+++ b/packages/icons-md/src/device/BatteryCharging50Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryCharging60Icon.tsx
+++ b/packages/icons-md/src/device/BatteryCharging60Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryCharging80Icon.tsx
+++ b/packages/icons-md/src/device/BatteryCharging80Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryCharging90Icon.tsx
+++ b/packages/icons-md/src/device/BatteryCharging90Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryChargingFullIcon.tsx
+++ b/packages/icons-md/src/device/BatteryChargingFullIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryFullIcon.tsx
+++ b/packages/icons-md/src/device/BatteryFullIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryStdIcon.tsx
+++ b/packages/icons-md/src/device/BatteryStdIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BatteryUnknownIcon.tsx
+++ b/packages/icons-md/src/device/BatteryUnknownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BluetoothConnectedIcon.tsx
+++ b/packages/icons-md/src/device/BluetoothConnectedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BluetoothDisabledIcon.tsx
+++ b/packages/icons-md/src/device/BluetoothDisabledIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BluetoothIcon.tsx
+++ b/packages/icons-md/src/device/BluetoothIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BluetoothSearchingIcon.tsx
+++ b/packages/icons-md/src/device/BluetoothSearchingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BrightnessAutoIcon.tsx
+++ b/packages/icons-md/src/device/BrightnessAutoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BrightnessHighIcon.tsx
+++ b/packages/icons-md/src/device/BrightnessHighIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BrightnessLowIcon.tsx
+++ b/packages/icons-md/src/device/BrightnessLowIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/BrightnessMediumIcon.tsx
+++ b/packages/icons-md/src/device/BrightnessMediumIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/DataUsageIcon.tsx
+++ b/packages/icons-md/src/device/DataUsageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/DeveloperModeIcon.tsx
+++ b/packages/icons-md/src/device/DeveloperModeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/DevicesIcon.tsx
+++ b/packages/icons-md/src/device/DevicesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/DvrIcon.tsx
+++ b/packages/icons-md/src/device/DvrIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/GpsFixedIcon.tsx
+++ b/packages/icons-md/src/device/GpsFixedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/GpsNotFixedIcon.tsx
+++ b/packages/icons-md/src/device/GpsNotFixedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/GpsOffIcon.tsx
+++ b/packages/icons-md/src/device/GpsOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/GraphicEqIcon.tsx
+++ b/packages/icons-md/src/device/GraphicEqIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/LocationDisabledIcon.tsx
+++ b/packages/icons-md/src/device/LocationDisabledIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/LocationSearchingIcon.tsx
+++ b/packages/icons-md/src/device/LocationSearchingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/NetworkCellIcon.tsx
+++ b/packages/icons-md/src/device/NetworkCellIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/NetworkWifiIcon.tsx
+++ b/packages/icons-md/src/device/NetworkWifiIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/NfcIcon.tsx
+++ b/packages/icons-md/src/device/NfcIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/ScreenLockLandscapeIcon.tsx
+++ b/packages/icons-md/src/device/ScreenLockLandscapeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/ScreenLockPortraitIcon.tsx
+++ b/packages/icons-md/src/device/ScreenLockPortraitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/ScreenLockRotationIcon.tsx
+++ b/packages/icons-md/src/device/ScreenLockRotationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/ScreenRotationIcon.tsx
+++ b/packages/icons-md/src/device/ScreenRotationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SdStorageIcon.tsx
+++ b/packages/icons-md/src/device/SdStorageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SettingsSystemDaydreamIcon.tsx
+++ b/packages/icons-md/src/device/SettingsSystemDaydreamIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellular0BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellular0BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellular1BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellular1BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellular2BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellular2BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellular3BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellular3BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellular4BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellular4BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularConnectedNoInternet0BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularConnectedNoInternet0BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularConnectedNoInternet1BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularConnectedNoInternet1BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularConnectedNoInternet2BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularConnectedNoInternet2BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularConnectedNoInternet3BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularConnectedNoInternet3BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularConnectedNoInternet4BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularConnectedNoInternet4BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularNoSimIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularNoSimIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularNullIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularNullIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalCellularOffIcon.tsx
+++ b/packages/icons-md/src/device/SignalCellularOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi0BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi0BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi1BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi1BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi1BarLockIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi1BarLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi2BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi2BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi2BarLockIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi2BarLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi3BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi3BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi3BarLockIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi3BarLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi4BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi4BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifi4BarLockIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifi4BarLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiOffIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbar1BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbar1BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbar2BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbar2BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbar3BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbar3BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbar4BarIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbar4BarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet1Icon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet1Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet2Icon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet2Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet3Icon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet3Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet4Icon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternet4Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternetIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarConnectedNoInternetIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarNotConnectedIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarNotConnectedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/SignalWifiStatusbarNullIcon.tsx
+++ b/packages/icons-md/src/device/SignalWifiStatusbarNullIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/StorageIcon.tsx
+++ b/packages/icons-md/src/device/StorageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/UsbIcon.tsx
+++ b/packages/icons-md/src/device/UsbIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/WallpaperIcon.tsx
+++ b/packages/icons-md/src/device/WallpaperIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/WidgetsIcon.tsx
+++ b/packages/icons-md/src/device/WidgetsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/WifiLockIcon.tsx
+++ b/packages/icons-md/src/device/WifiLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/device/WifiTetheringIcon.tsx
+++ b/packages/icons-md/src/device/WifiTetheringIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/AttachFileIcon.tsx
+++ b/packages/icons-md/src/editor/AttachFileIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/AttachMoneyIcon.tsx
+++ b/packages/icons-md/src/editor/AttachMoneyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderAllIcon.tsx
+++ b/packages/icons-md/src/editor/BorderAllIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderBottomIcon.tsx
+++ b/packages/icons-md/src/editor/BorderBottomIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderClearIcon.tsx
+++ b/packages/icons-md/src/editor/BorderClearIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderColorIcon.tsx
+++ b/packages/icons-md/src/editor/BorderColorIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderHorizontalIcon.tsx
+++ b/packages/icons-md/src/editor/BorderHorizontalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderInnerIcon.tsx
+++ b/packages/icons-md/src/editor/BorderInnerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderLeftIcon.tsx
+++ b/packages/icons-md/src/editor/BorderLeftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderOuterIcon.tsx
+++ b/packages/icons-md/src/editor/BorderOuterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderRightIcon.tsx
+++ b/packages/icons-md/src/editor/BorderRightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderStyleIcon.tsx
+++ b/packages/icons-md/src/editor/BorderStyleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderTopIcon.tsx
+++ b/packages/icons-md/src/editor/BorderTopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BorderVerticalIcon.tsx
+++ b/packages/icons-md/src/editor/BorderVerticalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/BubbleChartIcon.tsx
+++ b/packages/icons-md/src/editor/BubbleChartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle } from 'swgs';
+import { Svg, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/DragHandleIcon.tsx
+++ b/packages/icons-md/src/editor/DragHandleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatAlignCenterIcon.tsx
+++ b/packages/icons-md/src/editor/FormatAlignCenterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatAlignJustifyIcon.tsx
+++ b/packages/icons-md/src/editor/FormatAlignJustifyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatAlignLeftIcon.tsx
+++ b/packages/icons-md/src/editor/FormatAlignLeftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatAlignRightIcon.tsx
+++ b/packages/icons-md/src/editor/FormatAlignRightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatBoldIcon.tsx
+++ b/packages/icons-md/src/editor/FormatBoldIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatClearIcon.tsx
+++ b/packages/icons-md/src/editor/FormatClearIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatColorFillIcon.tsx
+++ b/packages/icons-md/src/editor/FormatColorFillIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatColorResetIcon.tsx
+++ b/packages/icons-md/src/editor/FormatColorResetIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatColorTextIcon.tsx
+++ b/packages/icons-md/src/editor/FormatColorTextIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatIndentDecreaseIcon.tsx
+++ b/packages/icons-md/src/editor/FormatIndentDecreaseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatIndentIncreaseIcon.tsx
+++ b/packages/icons-md/src/editor/FormatIndentIncreaseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatItalicIcon.tsx
+++ b/packages/icons-md/src/editor/FormatItalicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatLineSpacingIcon.tsx
+++ b/packages/icons-md/src/editor/FormatLineSpacingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatListBulletedIcon.tsx
+++ b/packages/icons-md/src/editor/FormatListBulletedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatListNumberedIcon.tsx
+++ b/packages/icons-md/src/editor/FormatListNumberedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatPaintIcon.tsx
+++ b/packages/icons-md/src/editor/FormatPaintIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatQuoteIcon.tsx
+++ b/packages/icons-md/src/editor/FormatQuoteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatShapesIcon.tsx
+++ b/packages/icons-md/src/editor/FormatShapesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatSizeIcon.tsx
+++ b/packages/icons-md/src/editor/FormatSizeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatStrikethroughIcon.tsx
+++ b/packages/icons-md/src/editor/FormatStrikethroughIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatTextdirectionLToRIcon.tsx
+++ b/packages/icons-md/src/editor/FormatTextdirectionLToRIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatTextdirectionRToLIcon.tsx
+++ b/packages/icons-md/src/editor/FormatTextdirectionRToLIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FormatUnderlinedIcon.tsx
+++ b/packages/icons-md/src/editor/FormatUnderlinedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/FunctionsIcon.tsx
+++ b/packages/icons-md/src/editor/FunctionsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/HighlightIcon.tsx
+++ b/packages/icons-md/src/editor/HighlightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertChartIcon.tsx
+++ b/packages/icons-md/src/editor/InsertChartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertCommentIcon.tsx
+++ b/packages/icons-md/src/editor/InsertCommentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertDriveFileIcon.tsx
+++ b/packages/icons-md/src/editor/InsertDriveFileIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertEmoticonIcon.tsx
+++ b/packages/icons-md/src/editor/InsertEmoticonIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertInvitationIcon.tsx
+++ b/packages/icons-md/src/editor/InsertInvitationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertLinkIcon.tsx
+++ b/packages/icons-md/src/editor/InsertLinkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/InsertPhotoIcon.tsx
+++ b/packages/icons-md/src/editor/InsertPhotoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/LinearScaleIcon.tsx
+++ b/packages/icons-md/src/editor/LinearScaleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/MergeTypeIcon.tsx
+++ b/packages/icons-md/src/editor/MergeTypeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/ModeCommentIcon.tsx
+++ b/packages/icons-md/src/editor/ModeCommentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/ModeEditIcon.tsx
+++ b/packages/icons-md/src/editor/ModeEditIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/MonetizationOnIcon.tsx
+++ b/packages/icons-md/src/editor/MonetizationOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/MoneyOffIcon.tsx
+++ b/packages/icons-md/src/editor/MoneyOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/MultilineChartIcon.tsx
+++ b/packages/icons-md/src/editor/MultilineChartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/PieChartIcon.tsx
+++ b/packages/icons-md/src/editor/PieChartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/PieChartOutlinedIcon.tsx
+++ b/packages/icons-md/src/editor/PieChartOutlinedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/PublishIcon.tsx
+++ b/packages/icons-md/src/editor/PublishIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/ShortTextIcon.tsx
+++ b/packages/icons-md/src/editor/ShortTextIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/ShowChartIcon.tsx
+++ b/packages/icons-md/src/editor/ShowChartIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/SpaceBarIcon.tsx
+++ b/packages/icons-md/src/editor/SpaceBarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/StrikethroughSIcon.tsx
+++ b/packages/icons-md/src/editor/StrikethroughSIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/TextFieldsIcon.tsx
+++ b/packages/icons-md/src/editor/TextFieldsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/TitleIcon.tsx
+++ b/packages/icons-md/src/editor/TitleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/VerticalAlignBottomIcon.tsx
+++ b/packages/icons-md/src/editor/VerticalAlignBottomIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/VerticalAlignCenterIcon.tsx
+++ b/packages/icons-md/src/editor/VerticalAlignCenterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/VerticalAlignTopIcon.tsx
+++ b/packages/icons-md/src/editor/VerticalAlignTopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/editor/WrapTextIcon.tsx
+++ b/packages/icons-md/src/editor/WrapTextIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/AttachmentIcon.tsx
+++ b/packages/icons-md/src/file/AttachmentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudCircleIcon.tsx
+++ b/packages/icons-md/src/file/CloudCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudDoneIcon.tsx
+++ b/packages/icons-md/src/file/CloudDoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudDownloadIcon.tsx
+++ b/packages/icons-md/src/file/CloudDownloadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudIcon.tsx
+++ b/packages/icons-md/src/file/CloudIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudOffIcon.tsx
+++ b/packages/icons-md/src/file/CloudOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudQueueIcon.tsx
+++ b/packages/icons-md/src/file/CloudQueueIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CloudUploadIcon.tsx
+++ b/packages/icons-md/src/file/CloudUploadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/CreateNewFolderIcon.tsx
+++ b/packages/icons-md/src/file/CreateNewFolderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/FileDownloadIcon.tsx
+++ b/packages/icons-md/src/file/FileDownloadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/FileUploadIcon.tsx
+++ b/packages/icons-md/src/file/FileUploadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/FolderIcon.tsx
+++ b/packages/icons-md/src/file/FolderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/FolderOpenIcon.tsx
+++ b/packages/icons-md/src/file/FolderOpenIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/file/FolderSharedIcon.tsx
+++ b/packages/icons-md/src/file/FolderSharedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/CastConnectedIcon.tsx
+++ b/packages/icons-md/src/hardware/CastConnectedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/CastIcon.tsx
+++ b/packages/icons-md/src/hardware/CastIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/ComputerIcon.tsx
+++ b/packages/icons-md/src/hardware/ComputerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/DesktopMacIcon.tsx
+++ b/packages/icons-md/src/hardware/DesktopMacIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/DesktopWindowsIcon.tsx
+++ b/packages/icons-md/src/hardware/DesktopWindowsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/DeveloperBoardIcon.tsx
+++ b/packages/icons-md/src/hardware/DeveloperBoardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/DeviceHubIcon.tsx
+++ b/packages/icons-md/src/hardware/DeviceHubIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/DevicesOtherIcon.tsx
+++ b/packages/icons-md/src/hardware/DevicesOtherIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/DockIcon.tsx
+++ b/packages/icons-md/src/hardware/DockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/GamepadIcon.tsx
+++ b/packages/icons-md/src/hardware/GamepadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/HeadsetIcon.tsx
+++ b/packages/icons-md/src/hardware/HeadsetIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/HeadsetMicIcon.tsx
+++ b/packages/icons-md/src/hardware/HeadsetMicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardArrowDownIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardArrowDownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardArrowLeftIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardArrowLeftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardArrowRightIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardArrowRightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardArrowUpIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardArrowUpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardBackspaceIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardBackspaceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardCapslockIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardCapslockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardHideIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardHideIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardReturnIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardReturnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardTabIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardTabIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/KeyboardVoiceIcon.tsx
+++ b/packages/icons-md/src/hardware/KeyboardVoiceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/LaptopChromebookIcon.tsx
+++ b/packages/icons-md/src/hardware/LaptopChromebookIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/LaptopIcon.tsx
+++ b/packages/icons-md/src/hardware/LaptopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/LaptopMacIcon.tsx
+++ b/packages/icons-md/src/hardware/LaptopMacIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/LaptopWindowsIcon.tsx
+++ b/packages/icons-md/src/hardware/LaptopWindowsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/MemoryIcon.tsx
+++ b/packages/icons-md/src/hardware/MemoryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/MouseIcon.tsx
+++ b/packages/icons-md/src/hardware/MouseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/PhoneAndroidIcon.tsx
+++ b/packages/icons-md/src/hardware/PhoneAndroidIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/PhoneIphoneIcon.tsx
+++ b/packages/icons-md/src/hardware/PhoneIphoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/PhonelinkIcon.tsx
+++ b/packages/icons-md/src/hardware/PhonelinkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/PhonelinkOffIcon.tsx
+++ b/packages/icons-md/src/hardware/PhonelinkOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/PowerInputIcon.tsx
+++ b/packages/icons-md/src/hardware/PowerInputIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/RouterIcon.tsx
+++ b/packages/icons-md/src/hardware/RouterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/ScannerIcon.tsx
+++ b/packages/icons-md/src/hardware/ScannerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/SecurityIcon.tsx
+++ b/packages/icons-md/src/hardware/SecurityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/SimCardIcon.tsx
+++ b/packages/icons-md/src/hardware/SimCardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/SmartphoneIcon.tsx
+++ b/packages/icons-md/src/hardware/SmartphoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/SpeakerGroupIcon.tsx
+++ b/packages/icons-md/src/hardware/SpeakerGroupIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path, Circle } from 'swgs';
+import { Svg, Path, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/SpeakerIcon.tsx
+++ b/packages/icons-md/src/hardware/SpeakerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/TabletAndroidIcon.tsx
+++ b/packages/icons-md/src/hardware/TabletAndroidIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/TabletIcon.tsx
+++ b/packages/icons-md/src/hardware/TabletIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/TabletMacIcon.tsx
+++ b/packages/icons-md/src/hardware/TabletMacIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/ToysIcon.tsx
+++ b/packages/icons-md/src/hardware/ToysIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/TvIcon.tsx
+++ b/packages/icons-md/src/hardware/TvIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/VideogameAssetIcon.tsx
+++ b/packages/icons-md/src/hardware/VideogameAssetIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/hardware/WatchIcon.tsx
+++ b/packages/icons-md/src/hardware/WatchIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/AddAPhotoIcon.tsx
+++ b/packages/icons-md/src/image/AddAPhotoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/AddToPhotosIcon.tsx
+++ b/packages/icons-md/src/image/AddToPhotosIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/AdjustIcon.tsx
+++ b/packages/icons-md/src/image/AdjustIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/AssistantIcon.tsx
+++ b/packages/icons-md/src/image/AssistantIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/AssistantPhotoIcon.tsx
+++ b/packages/icons-md/src/image/AssistantPhotoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/AudiotrackIcon.tsx
+++ b/packages/icons-md/src/image/AudiotrackIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BlurCircularIcon.tsx
+++ b/packages/icons-md/src/image/BlurCircularIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BlurLinearIcon.tsx
+++ b/packages/icons-md/src/image/BlurLinearIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BlurOffIcon.tsx
+++ b/packages/icons-md/src/image/BlurOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BlurOnIcon.tsx
+++ b/packages/icons-md/src/image/BlurOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness1Icon.tsx
+++ b/packages/icons-md/src/image/Brightness1Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle } from 'swgs';
+import { Svg, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness2Icon.tsx
+++ b/packages/icons-md/src/image/Brightness2Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness3Icon.tsx
+++ b/packages/icons-md/src/image/Brightness3Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness4Icon.tsx
+++ b/packages/icons-md/src/image/Brightness4Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness5Icon.tsx
+++ b/packages/icons-md/src/image/Brightness5Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness6Icon.tsx
+++ b/packages/icons-md/src/image/Brightness6Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Brightness7Icon.tsx
+++ b/packages/icons-md/src/image/Brightness7Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BrokenImageIcon.tsx
+++ b/packages/icons-md/src/image/BrokenImageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BrushIcon.tsx
+++ b/packages/icons-md/src/image/BrushIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/BurstModeIcon.tsx
+++ b/packages/icons-md/src/image/BurstModeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CameraAltIcon.tsx
+++ b/packages/icons-md/src/image/CameraAltIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CameraFrontIcon.tsx
+++ b/packages/icons-md/src/image/CameraFrontIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CameraIcon.tsx
+++ b/packages/icons-md/src/image/CameraIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CameraRearIcon.tsx
+++ b/packages/icons-md/src/image/CameraRearIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CameraRollIcon.tsx
+++ b/packages/icons-md/src/image/CameraRollIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CenterFocusStrongIcon.tsx
+++ b/packages/icons-md/src/image/CenterFocusStrongIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CenterFocusWeakIcon.tsx
+++ b/packages/icons-md/src/image/CenterFocusWeakIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CollectionsBookmarkIcon.tsx
+++ b/packages/icons-md/src/image/CollectionsBookmarkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CollectionsIcon.tsx
+++ b/packages/icons-md/src/image/CollectionsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ColorLensIcon.tsx
+++ b/packages/icons-md/src/image/ColorLensIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ColorizeIcon.tsx
+++ b/packages/icons-md/src/image/ColorizeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CompareIcon.tsx
+++ b/packages/icons-md/src/image/CompareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ControlPointDuplicateIcon.tsx
+++ b/packages/icons-md/src/image/ControlPointDuplicateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ControlPointIcon.tsx
+++ b/packages/icons-md/src/image/ControlPointIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Crop169Icon.tsx
+++ b/packages/icons-md/src/image/Crop169Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Crop32Icon.tsx
+++ b/packages/icons-md/src/image/Crop32Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Crop54Icon.tsx
+++ b/packages/icons-md/src/image/Crop54Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Crop75Icon.tsx
+++ b/packages/icons-md/src/image/Crop75Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropDinIcon.tsx
+++ b/packages/icons-md/src/image/CropDinIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropFreeIcon.tsx
+++ b/packages/icons-md/src/image/CropFreeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropIcon.tsx
+++ b/packages/icons-md/src/image/CropIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropLandscapeIcon.tsx
+++ b/packages/icons-md/src/image/CropLandscapeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropOriginalIcon.tsx
+++ b/packages/icons-md/src/image/CropOriginalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropPortraitIcon.tsx
+++ b/packages/icons-md/src/image/CropPortraitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropRotateIcon.tsx
+++ b/packages/icons-md/src/image/CropRotateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/CropSquareIcon.tsx
+++ b/packages/icons-md/src/image/CropSquareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/DehazeIcon.tsx
+++ b/packages/icons-md/src/image/DehazeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/DetailsIcon.tsx
+++ b/packages/icons-md/src/image/DetailsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/EditIcon.tsx
+++ b/packages/icons-md/src/image/EditIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ExposureIcon.tsx
+++ b/packages/icons-md/src/image/ExposureIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ExposureNeg1Icon.tsx
+++ b/packages/icons-md/src/image/ExposureNeg1Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ExposureNeg2Icon.tsx
+++ b/packages/icons-md/src/image/ExposureNeg2Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ExposurePlus1Icon.tsx
+++ b/packages/icons-md/src/image/ExposurePlus1Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ExposurePlus2Icon.tsx
+++ b/packages/icons-md/src/image/ExposurePlus2Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ExposureZeroIcon.tsx
+++ b/packages/icons-md/src/image/ExposureZeroIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter1Icon.tsx
+++ b/packages/icons-md/src/image/Filter1Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter2Icon.tsx
+++ b/packages/icons-md/src/image/Filter2Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter3Icon.tsx
+++ b/packages/icons-md/src/image/Filter3Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter4Icon.tsx
+++ b/packages/icons-md/src/image/Filter4Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter5Icon.tsx
+++ b/packages/icons-md/src/image/Filter5Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter6Icon.tsx
+++ b/packages/icons-md/src/image/Filter6Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter7Icon.tsx
+++ b/packages/icons-md/src/image/Filter7Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter8Icon.tsx
+++ b/packages/icons-md/src/image/Filter8Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter9Icon.tsx
+++ b/packages/icons-md/src/image/Filter9Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Filter9PlusIcon.tsx
+++ b/packages/icons-md/src/image/Filter9PlusIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterBAndWIcon.tsx
+++ b/packages/icons-md/src/image/FilterBAndWIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterCenterFocusIcon.tsx
+++ b/packages/icons-md/src/image/FilterCenterFocusIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterDramaIcon.tsx
+++ b/packages/icons-md/src/image/FilterDramaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterFramesIcon.tsx
+++ b/packages/icons-md/src/image/FilterFramesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterHdrIcon.tsx
+++ b/packages/icons-md/src/image/FilterHdrIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterIcon.tsx
+++ b/packages/icons-md/src/image/FilterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterNoneIcon.tsx
+++ b/packages/icons-md/src/image/FilterNoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterTiltShiftIcon.tsx
+++ b/packages/icons-md/src/image/FilterTiltShiftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FilterVintageIcon.tsx
+++ b/packages/icons-md/src/image/FilterVintageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FlareIcon.tsx
+++ b/packages/icons-md/src/image/FlareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FlashAutoIcon.tsx
+++ b/packages/icons-md/src/image/FlashAutoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FlashOffIcon.tsx
+++ b/packages/icons-md/src/image/FlashOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FlashOnIcon.tsx
+++ b/packages/icons-md/src/image/FlashOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/FlipIcon.tsx
+++ b/packages/icons-md/src/image/FlipIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/GradientIcon.tsx
+++ b/packages/icons-md/src/image/GradientIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/GrainIcon.tsx
+++ b/packages/icons-md/src/image/GrainIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/GridOffIcon.tsx
+++ b/packages/icons-md/src/image/GridOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/GridOnIcon.tsx
+++ b/packages/icons-md/src/image/GridOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/HdrOffIcon.tsx
+++ b/packages/icons-md/src/image/HdrOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/HdrOnIcon.tsx
+++ b/packages/icons-md/src/image/HdrOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/HdrStrongIcon.tsx
+++ b/packages/icons-md/src/image/HdrStrongIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/HdrWeakIcon.tsx
+++ b/packages/icons-md/src/image/HdrWeakIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/HealingIcon.tsx
+++ b/packages/icons-md/src/image/HealingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ImageAspectRatioIcon.tsx
+++ b/packages/icons-md/src/image/ImageAspectRatioIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ImageIcon.tsx
+++ b/packages/icons-md/src/image/ImageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/IsoIcon.tsx
+++ b/packages/icons-md/src/image/IsoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LandscapeIcon.tsx
+++ b/packages/icons-md/src/image/LandscapeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LeakAddIcon.tsx
+++ b/packages/icons-md/src/image/LeakAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LeakRemoveIcon.tsx
+++ b/packages/icons-md/src/image/LeakRemoveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LensIcon.tsx
+++ b/packages/icons-md/src/image/LensIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LinkedCameraIcon.tsx
+++ b/packages/icons-md/src/image/LinkedCameraIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Looks3Icon.tsx
+++ b/packages/icons-md/src/image/Looks3Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Looks4Icon.tsx
+++ b/packages/icons-md/src/image/Looks4Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Looks5Icon.tsx
+++ b/packages/icons-md/src/image/Looks5Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Looks6Icon.tsx
+++ b/packages/icons-md/src/image/Looks6Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LooksIcon.tsx
+++ b/packages/icons-md/src/image/LooksIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LooksOneIcon.tsx
+++ b/packages/icons-md/src/image/LooksOneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LooksTwoIcon.tsx
+++ b/packages/icons-md/src/image/LooksTwoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/LoupeIcon.tsx
+++ b/packages/icons-md/src/image/LoupeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/MonochromePhotosIcon.tsx
+++ b/packages/icons-md/src/image/MonochromePhotosIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/MovieCreationIcon.tsx
+++ b/packages/icons-md/src/image/MovieCreationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/MovieFilterIcon.tsx
+++ b/packages/icons-md/src/image/MovieFilterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/MusicNoteIcon.tsx
+++ b/packages/icons-md/src/image/MusicNoteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/NatureIcon.tsx
+++ b/packages/icons-md/src/image/NatureIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/NaturePeopleIcon.tsx
+++ b/packages/icons-md/src/image/NaturePeopleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/NavigateBeforeIcon.tsx
+++ b/packages/icons-md/src/image/NavigateBeforeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/NavigateNextIcon.tsx
+++ b/packages/icons-md/src/image/NavigateNextIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PaletteIcon.tsx
+++ b/packages/icons-md/src/image/PaletteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PanoramaFishEyeIcon.tsx
+++ b/packages/icons-md/src/image/PanoramaFishEyeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PanoramaHorizontalIcon.tsx
+++ b/packages/icons-md/src/image/PanoramaHorizontalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PanoramaIcon.tsx
+++ b/packages/icons-md/src/image/PanoramaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PanoramaVerticalIcon.tsx
+++ b/packages/icons-md/src/image/PanoramaVerticalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PanoramaWideAngleIcon.tsx
+++ b/packages/icons-md/src/image/PanoramaWideAngleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoAlbumIcon.tsx
+++ b/packages/icons-md/src/image/PhotoAlbumIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoCameraIcon.tsx
+++ b/packages/icons-md/src/image/PhotoCameraIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoFilterIcon.tsx
+++ b/packages/icons-md/src/image/PhotoFilterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoIcon.tsx
+++ b/packages/icons-md/src/image/PhotoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoLibraryIcon.tsx
+++ b/packages/icons-md/src/image/PhotoLibraryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoSizeSelectActualIcon.tsx
+++ b/packages/icons-md/src/image/PhotoSizeSelectActualIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoSizeSelectLargeIcon.tsx
+++ b/packages/icons-md/src/image/PhotoSizeSelectLargeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PhotoSizeSelectSmallIcon.tsx
+++ b/packages/icons-md/src/image/PhotoSizeSelectSmallIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PictureAsPdfIcon.tsx
+++ b/packages/icons-md/src/image/PictureAsPdfIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/PortraitIcon.tsx
+++ b/packages/icons-md/src/image/PortraitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/RemoveRedEyeIcon.tsx
+++ b/packages/icons-md/src/image/RemoveRedEyeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Rotate90DegreesCcwIcon.tsx
+++ b/packages/icons-md/src/image/Rotate90DegreesCcwIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/RotateLeftIcon.tsx
+++ b/packages/icons-md/src/image/RotateLeftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/RotateRightIcon.tsx
+++ b/packages/icons-md/src/image/RotateRightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/SlideshowIcon.tsx
+++ b/packages/icons-md/src/image/SlideshowIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/StraightenIcon.tsx
+++ b/packages/icons-md/src/image/StraightenIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/StyleIcon.tsx
+++ b/packages/icons-md/src/image/StyleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/SwitchCameraIcon.tsx
+++ b/packages/icons-md/src/image/SwitchCameraIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/SwitchVideoIcon.tsx
+++ b/packages/icons-md/src/image/SwitchVideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TagFacesIcon.tsx
+++ b/packages/icons-md/src/image/TagFacesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TextureIcon.tsx
+++ b/packages/icons-md/src/image/TextureIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TimelapseIcon.tsx
+++ b/packages/icons-md/src/image/TimelapseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Timer10Icon.tsx
+++ b/packages/icons-md/src/image/Timer10Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/Timer3Icon.tsx
+++ b/packages/icons-md/src/image/Timer3Icon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TimerIcon.tsx
+++ b/packages/icons-md/src/image/TimerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TimerOffIcon.tsx
+++ b/packages/icons-md/src/image/TimerOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TonalityIcon.tsx
+++ b/packages/icons-md/src/image/TonalityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TransformIcon.tsx
+++ b/packages/icons-md/src/image/TransformIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/TuneIcon.tsx
+++ b/packages/icons-md/src/image/TuneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ViewComfyIcon.tsx
+++ b/packages/icons-md/src/image/ViewComfyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/ViewCompactIcon.tsx
+++ b/packages/icons-md/src/image/ViewCompactIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/VignetteIcon.tsx
+++ b/packages/icons-md/src/image/VignetteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/WbAutoIcon.tsx
+++ b/packages/icons-md/src/image/WbAutoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/WbCloudyIcon.tsx
+++ b/packages/icons-md/src/image/WbCloudyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/WbIncandescentIcon.tsx
+++ b/packages/icons-md/src/image/WbIncandescentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/WbIridescentIcon.tsx
+++ b/packages/icons-md/src/image/WbIridescentIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/image/WbSunnyIcon.tsx
+++ b/packages/icons-md/src/image/WbSunnyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/AddLocationIcon.tsx
+++ b/packages/icons-md/src/maps/AddLocationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/BeenhereIcon.tsx
+++ b/packages/icons-md/src/maps/BeenhereIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsBikeIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsBikeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsBoatIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsBoatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsBusIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsBusIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsCarIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsCarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsRailwayIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsRailwayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsRunIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsRunIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsSubwayIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsSubwayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsTransitIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsTransitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/DirectionsWalkIcon.tsx
+++ b/packages/icons-md/src/maps/DirectionsWalkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/EditLocationIcon.tsx
+++ b/packages/icons-md/src/maps/EditLocationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/EvStationIcon.tsx
+++ b/packages/icons-md/src/maps/EvStationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/FlightIcon.tsx
+++ b/packages/icons-md/src/maps/FlightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/HotelIcon.tsx
+++ b/packages/icons-md/src/maps/HotelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LayersClearIcon.tsx
+++ b/packages/icons-md/src/maps/LayersClearIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LayersIcon.tsx
+++ b/packages/icons-md/src/maps/LayersIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalActivityIcon.tsx
+++ b/packages/icons-md/src/maps/LocalActivityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalAirportIcon.tsx
+++ b/packages/icons-md/src/maps/LocalAirportIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalAtmIcon.tsx
+++ b/packages/icons-md/src/maps/LocalAtmIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalBarIcon.tsx
+++ b/packages/icons-md/src/maps/LocalBarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalCafeIcon.tsx
+++ b/packages/icons-md/src/maps/LocalCafeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalCarWashIcon.tsx
+++ b/packages/icons-md/src/maps/LocalCarWashIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalConvenienceStoreIcon.tsx
+++ b/packages/icons-md/src/maps/LocalConvenienceStoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalDiningIcon.tsx
+++ b/packages/icons-md/src/maps/LocalDiningIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalDrinkIcon.tsx
+++ b/packages/icons-md/src/maps/LocalDrinkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalFloristIcon.tsx
+++ b/packages/icons-md/src/maps/LocalFloristIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalGasStationIcon.tsx
+++ b/packages/icons-md/src/maps/LocalGasStationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalGroceryStoreIcon.tsx
+++ b/packages/icons-md/src/maps/LocalGroceryStoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalHospitalIcon.tsx
+++ b/packages/icons-md/src/maps/LocalHospitalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalHotelIcon.tsx
+++ b/packages/icons-md/src/maps/LocalHotelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalLaundryServiceIcon.tsx
+++ b/packages/icons-md/src/maps/LocalLaundryServiceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalLibraryIcon.tsx
+++ b/packages/icons-md/src/maps/LocalLibraryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalMallIcon.tsx
+++ b/packages/icons-md/src/maps/LocalMallIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalMoviesIcon.tsx
+++ b/packages/icons-md/src/maps/LocalMoviesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalOfferIcon.tsx
+++ b/packages/icons-md/src/maps/LocalOfferIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalParkingIcon.tsx
+++ b/packages/icons-md/src/maps/LocalParkingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalPharmacyIcon.tsx
+++ b/packages/icons-md/src/maps/LocalPharmacyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalPhoneIcon.tsx
+++ b/packages/icons-md/src/maps/LocalPhoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalPizzaIcon.tsx
+++ b/packages/icons-md/src/maps/LocalPizzaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalPlayIcon.tsx
+++ b/packages/icons-md/src/maps/LocalPlayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalPostOfficeIcon.tsx
+++ b/packages/icons-md/src/maps/LocalPostOfficeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalPrintshopIcon.tsx
+++ b/packages/icons-md/src/maps/LocalPrintshopIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalSeeIcon.tsx
+++ b/packages/icons-md/src/maps/LocalSeeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalShippingIcon.tsx
+++ b/packages/icons-md/src/maps/LocalShippingIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/LocalTaxiIcon.tsx
+++ b/packages/icons-md/src/maps/LocalTaxiIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/MapIcon.tsx
+++ b/packages/icons-md/src/maps/MapIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/MyLocationIcon.tsx
+++ b/packages/icons-md/src/maps/MyLocationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/NavigationIcon.tsx
+++ b/packages/icons-md/src/maps/NavigationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/NearMeIcon.tsx
+++ b/packages/icons-md/src/maps/NearMeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/PersonPinCircleIcon.tsx
+++ b/packages/icons-md/src/maps/PersonPinCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/PersonPinIcon.tsx
+++ b/packages/icons-md/src/maps/PersonPinIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/PinDropIcon.tsx
+++ b/packages/icons-md/src/maps/PinDropIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/PlaceIcon.tsx
+++ b/packages/icons-md/src/maps/PlaceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/RateReviewIcon.tsx
+++ b/packages/icons-md/src/maps/RateReviewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/RestaurantIcon.tsx
+++ b/packages/icons-md/src/maps/RestaurantIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/RestaurantMenuIcon.tsx
+++ b/packages/icons-md/src/maps/RestaurantMenuIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/SatelliteIcon.tsx
+++ b/packages/icons-md/src/maps/SatelliteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/StoreMallDirectoryIcon.tsx
+++ b/packages/icons-md/src/maps/StoreMallDirectoryIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/StreetviewIcon.tsx
+++ b/packages/icons-md/src/maps/StreetviewIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path, Circle } from 'swgs';
+import { Svg, Path, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/SubwayIcon.tsx
+++ b/packages/icons-md/src/maps/SubwayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/TerrainIcon.tsx
+++ b/packages/icons-md/src/maps/TerrainIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/TrafficIcon.tsx
+++ b/packages/icons-md/src/maps/TrafficIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/TrainIcon.tsx
+++ b/packages/icons-md/src/maps/TrainIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/TramIcon.tsx
+++ b/packages/icons-md/src/maps/TramIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/TransferWithinAStationIcon.tsx
+++ b/packages/icons-md/src/maps/TransferWithinAStationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/maps/ZoomOutMapIcon.tsx
+++ b/packages/icons-md/src/maps/ZoomOutMapIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/AppsIcon.tsx
+++ b/packages/icons-md/src/navigation/AppsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowBackIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowBackIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowDownwardIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowDownwardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowDropDownCircleIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowDropDownCircleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowDropDownIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowDropDownIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowDropUpIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowDropUpIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowForwardIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowForwardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ArrowUpwardIcon.tsx
+++ b/packages/icons-md/src/navigation/ArrowUpwardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/CancelIcon.tsx
+++ b/packages/icons-md/src/navigation/CancelIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/CheckIcon.tsx
+++ b/packages/icons-md/src/navigation/CheckIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ChevronLeftIcon.tsx
+++ b/packages/icons-md/src/navigation/ChevronLeftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ChevronRightIcon.tsx
+++ b/packages/icons-md/src/navigation/ChevronRightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/CloseIcon.tsx
+++ b/packages/icons-md/src/navigation/CloseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ExpandLessIcon.tsx
+++ b/packages/icons-md/src/navigation/ExpandLessIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/ExpandMoreIcon.tsx
+++ b/packages/icons-md/src/navigation/ExpandMoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/FirstPageIcon.tsx
+++ b/packages/icons-md/src/navigation/FirstPageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/FullscreenExitIcon.tsx
+++ b/packages/icons-md/src/navigation/FullscreenExitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/FullscreenIcon.tsx
+++ b/packages/icons-md/src/navigation/FullscreenIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/LastPageIcon.tsx
+++ b/packages/icons-md/src/navigation/LastPageIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/MenuIcon.tsx
+++ b/packages/icons-md/src/navigation/MenuIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/MoreHorizIcon.tsx
+++ b/packages/icons-md/src/navigation/MoreHorizIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/MoreVertIcon.tsx
+++ b/packages/icons-md/src/navigation/MoreVertIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/RefreshIcon.tsx
+++ b/packages/icons-md/src/navigation/RefreshIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/SubdirectoryArrowLeftIcon.tsx
+++ b/packages/icons-md/src/navigation/SubdirectoryArrowLeftIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/SubdirectoryArrowRightIcon.tsx
+++ b/packages/icons-md/src/navigation/SubdirectoryArrowRightIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/UnfoldLessIcon.tsx
+++ b/packages/icons-md/src/navigation/UnfoldLessIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/navigation/UnfoldMoreIcon.tsx
+++ b/packages/icons-md/src/navigation/UnfoldMoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AdbIcon.tsx
+++ b/packages/icons-md/src/notification/AdbIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatFlatAngledIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatFlatAngledIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatFlatIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatFlatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatIndividualSuiteIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatIndividualSuiteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatLegroomExtraIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatLegroomExtraIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatLegroomNormalIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatLegroomNormalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatLegroomReducedIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatLegroomReducedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatReclineExtraIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatReclineExtraIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/AirlineSeatReclineNormalIcon.tsx
+++ b/packages/icons-md/src/notification/AirlineSeatReclineNormalIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/BluetoothAudioIcon.tsx
+++ b/packages/icons-md/src/notification/BluetoothAudioIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/ConfirmationNumberIcon.tsx
+++ b/packages/icons-md/src/notification/ConfirmationNumberIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/DiscFullIcon.tsx
+++ b/packages/icons-md/src/notification/DiscFullIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/DoNotDisturbAltIcon.tsx
+++ b/packages/icons-md/src/notification/DoNotDisturbAltIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/DoNotDisturbIcon.tsx
+++ b/packages/icons-md/src/notification/DoNotDisturbIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/DoNotDisturbOffIcon.tsx
+++ b/packages/icons-md/src/notification/DoNotDisturbOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/DoNotDisturbOnIcon.tsx
+++ b/packages/icons-md/src/notification/DoNotDisturbOnIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/DriveEtaIcon.tsx
+++ b/packages/icons-md/src/notification/DriveEtaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/EnhancedEncryptionIcon.tsx
+++ b/packages/icons-md/src/notification/EnhancedEncryptionIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/EventAvailableIcon.tsx
+++ b/packages/icons-md/src/notification/EventAvailableIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/EventBusyIcon.tsx
+++ b/packages/icons-md/src/notification/EventBusyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/EventNoteIcon.tsx
+++ b/packages/icons-md/src/notification/EventNoteIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/FolderSpecialIcon.tsx
+++ b/packages/icons-md/src/notification/FolderSpecialIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/LiveTvIcon.tsx
+++ b/packages/icons-md/src/notification/LiveTvIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/MmsIcon.tsx
+++ b/packages/icons-md/src/notification/MmsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/MoreIcon.tsx
+++ b/packages/icons-md/src/notification/MoreIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/NetworkCheckIcon.tsx
+++ b/packages/icons-md/src/notification/NetworkCheckIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/NetworkLockedIcon.tsx
+++ b/packages/icons-md/src/notification/NetworkLockedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/NoEncryptionIcon.tsx
+++ b/packages/icons-md/src/notification/NoEncryptionIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/OndemandVideoIcon.tsx
+++ b/packages/icons-md/src/notification/OndemandVideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PersonalVideoIcon.tsx
+++ b/packages/icons-md/src/notification/PersonalVideoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PhoneBluetoothSpeakerIcon.tsx
+++ b/packages/icons-md/src/notification/PhoneBluetoothSpeakerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PhoneForwardedIcon.tsx
+++ b/packages/icons-md/src/notification/PhoneForwardedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PhoneInTalkIcon.tsx
+++ b/packages/icons-md/src/notification/PhoneInTalkIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PhoneLockedIcon.tsx
+++ b/packages/icons-md/src/notification/PhoneLockedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PhoneMissedIcon.tsx
+++ b/packages/icons-md/src/notification/PhoneMissedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PhonePausedIcon.tsx
+++ b/packages/icons-md/src/notification/PhonePausedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PowerIcon.tsx
+++ b/packages/icons-md/src/notification/PowerIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/PriorityHighIcon.tsx
+++ b/packages/icons-md/src/notification/PriorityHighIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/RvHookupIcon.tsx
+++ b/packages/icons-md/src/notification/RvHookupIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SdCardIcon.tsx
+++ b/packages/icons-md/src/notification/SdCardIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SimCardAlertIcon.tsx
+++ b/packages/icons-md/src/notification/SimCardAlertIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SmsFailedIcon.tsx
+++ b/packages/icons-md/src/notification/SmsFailedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SmsIcon.tsx
+++ b/packages/icons-md/src/notification/SmsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SyncDisabledIcon.tsx
+++ b/packages/icons-md/src/notification/SyncDisabledIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SyncIcon.tsx
+++ b/packages/icons-md/src/notification/SyncIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SyncProblemIcon.tsx
+++ b/packages/icons-md/src/notification/SyncProblemIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/SystemUpdateIcon.tsx
+++ b/packages/icons-md/src/notification/SystemUpdateIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/TapAndPlayIcon.tsx
+++ b/packages/icons-md/src/notification/TapAndPlayIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/TimeToLeaveIcon.tsx
+++ b/packages/icons-md/src/notification/TimeToLeaveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/VibrationIcon.tsx
+++ b/packages/icons-md/src/notification/VibrationIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/VoiceChatIcon.tsx
+++ b/packages/icons-md/src/notification/VoiceChatIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/VpnLockIcon.tsx
+++ b/packages/icons-md/src/notification/VpnLockIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/WcIcon.tsx
+++ b/packages/icons-md/src/notification/WcIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/notification/WifiIcon.tsx
+++ b/packages/icons-md/src/notification/WifiIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/AcUnitIcon.tsx
+++ b/packages/icons-md/src/places/AcUnitIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/AirportShuttleIcon.tsx
+++ b/packages/icons-md/src/places/AirportShuttleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/AllInclusiveIcon.tsx
+++ b/packages/icons-md/src/places/AllInclusiveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/BeachAccessIcon.tsx
+++ b/packages/icons-md/src/places/BeachAccessIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/BusinessCenterIcon.tsx
+++ b/packages/icons-md/src/places/BusinessCenterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/CasinoIcon.tsx
+++ b/packages/icons-md/src/places/CasinoIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/ChildCareIcon.tsx
+++ b/packages/icons-md/src/places/ChildCareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/ChildFriendlyIcon.tsx
+++ b/packages/icons-md/src/places/ChildFriendlyIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/FitnessCenterIcon.tsx
+++ b/packages/icons-md/src/places/FitnessCenterIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/FreeBreakfastIcon.tsx
+++ b/packages/icons-md/src/places/FreeBreakfastIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/GolfCourseIcon.tsx
+++ b/packages/icons-md/src/places/GolfCourseIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/HotTubIcon.tsx
+++ b/packages/icons-md/src/places/HotTubIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/KitchenIcon.tsx
+++ b/packages/icons-md/src/places/KitchenIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/PoolIcon.tsx
+++ b/packages/icons-md/src/places/PoolIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path, Circle } from 'swgs';
+import { Svg, Path, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/RoomServiceIcon.tsx
+++ b/packages/icons-md/src/places/RoomServiceIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/SmokeFreeIcon.tsx
+++ b/packages/icons-md/src/places/SmokeFreeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/SmokingRoomsIcon.tsx
+++ b/packages/icons-md/src/places/SmokingRoomsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/places/SpaIcon.tsx
+++ b/packages/icons-md/src/places/SpaIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/CakeIcon.tsx
+++ b/packages/icons-md/src/social/CakeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/DomainIcon.tsx
+++ b/packages/icons-md/src/social/DomainIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/GroupAddIcon.tsx
+++ b/packages/icons-md/src/social/GroupAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/GroupIcon.tsx
+++ b/packages/icons-md/src/social/GroupIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/LocationCityIcon.tsx
+++ b/packages/icons-md/src/social/LocationCityIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/MoodBadIcon.tsx
+++ b/packages/icons-md/src/social/MoodBadIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/MoodIcon.tsx
+++ b/packages/icons-md/src/social/MoodIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/NotificationsActiveIcon.tsx
+++ b/packages/icons-md/src/social/NotificationsActiveIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/NotificationsIcon.tsx
+++ b/packages/icons-md/src/social/NotificationsIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/NotificationsNoneIcon.tsx
+++ b/packages/icons-md/src/social/NotificationsNoneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/NotificationsOffIcon.tsx
+++ b/packages/icons-md/src/social/NotificationsOffIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/NotificationsPausedIcon.tsx
+++ b/packages/icons-md/src/social/NotificationsPausedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PagesIcon.tsx
+++ b/packages/icons-md/src/social/PagesIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PartyModeIcon.tsx
+++ b/packages/icons-md/src/social/PartyModeIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PeopleIcon.tsx
+++ b/packages/icons-md/src/social/PeopleIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PeopleOutlineIcon.tsx
+++ b/packages/icons-md/src/social/PeopleOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PersonAddIcon.tsx
+++ b/packages/icons-md/src/social/PersonAddIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PersonIcon.tsx
+++ b/packages/icons-md/src/social/PersonIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PersonOutlineIcon.tsx
+++ b/packages/icons-md/src/social/PersonOutlineIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PlusOneIcon.tsx
+++ b/packages/icons-md/src/social/PlusOneIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PollIcon.tsx
+++ b/packages/icons-md/src/social/PollIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/PublicIcon.tsx
+++ b/packages/icons-md/src/social/PublicIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/SchoolIcon.tsx
+++ b/packages/icons-md/src/social/SchoolIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/SentimentDissatisfiedIcon.tsx
+++ b/packages/icons-md/src/social/SentimentDissatisfiedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/SentimentNeutralIcon.tsx
+++ b/packages/icons-md/src/social/SentimentNeutralIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path, Circle } from 'swgs';
+import { Svg, Path, Circle } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/SentimentSatisfiedIcon.tsx
+++ b/packages/icons-md/src/social/SentimentSatisfiedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Circle, Path } from 'swgs';
+import { Svg, Circle, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/SentimentVeryDissatisfiedIcon.tsx
+++ b/packages/icons-md/src/social/SentimentVeryDissatisfiedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/SentimentVerySatisfiedIcon.tsx
+++ b/packages/icons-md/src/social/SentimentVerySatisfiedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/ShareIcon.tsx
+++ b/packages/icons-md/src/social/ShareIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/social/WhatshotIcon.tsx
+++ b/packages/icons-md/src/social/WhatshotIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/CheckBoxIcon.tsx
+++ b/packages/icons-md/src/toggle/CheckBoxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/CheckBoxOutlineBlankIcon.tsx
+++ b/packages/icons-md/src/toggle/CheckBoxOutlineBlankIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/IndeterminateCheckBoxIcon.tsx
+++ b/packages/icons-md/src/toggle/IndeterminateCheckBoxIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/RadioButtonCheckedIcon.tsx
+++ b/packages/icons-md/src/toggle/RadioButtonCheckedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/RadioButtonUncheckedIcon.tsx
+++ b/packages/icons-md/src/toggle/RadioButtonUncheckedIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/StarBorderIcon.tsx
+++ b/packages/icons-md/src/toggle/StarBorderIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/StarHalfIcon.tsx
+++ b/packages/icons-md/src/toggle/StarHalfIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/icons-md/src/toggle/StarIcon.tsx
+++ b/packages/icons-md/src/toggle/StarIcon.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
+import React from 'react';
 // tslint:disable-next-line:ordered-imports
-import { Svg, Path } from 'swgs';
+import { Svg, Path } from 'react-native-svg';
 
 import {
   processComponent,

--- a/packages/svg2jsx/src/generate.ts
+++ b/packages/svg2jsx/src/generate.ts
@@ -164,12 +164,11 @@ export const svg2jsx: FileDataTransformer = ({ fileData, filePath }) => {
 export const svgr2SvgIcon: FileDataTransformer = ({ fileData, filePath }) => {
   let svgIcon: string = fileData.replace(
     'import React from "react";',
-    `import * as React from 'react';
+    `import React from "react";
     // tslint:disable-next-line:ordered-imports`,
   );
 
   svgIcon = svgIcon.replace('import Svg, { ', 'import { Svg, ');
-  svgIcon = svgIcon.replace(/react-native-svg/g, 'swgs');
 
   svgIcon = svgIcon.replace(
     'const SvgComponent = props => ',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9048,7 +9048,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@15.x.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@15.x.x, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9328,10 +9328,10 @@ react-native-navigation@2.15.0:
     react-lifecycles-compat "2.0.0"
     tslib "1.9.3"
 
-react-native-svg@9.3.5:
-  version "9.3.5"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.3.5.tgz#86ea5f6de4b9996c51784c3e7f84859915519466"
-  integrity sha512-wQqW8NxePnXGOGcWo6zGsEucNQ6L+5qjstTGH8n6cLN79dI1v3yavYwYxmd5m/kTtaEv1ZtQz3qb990UFiyw3w==
+react-native-svg@9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-9.4.0.tgz#e428e0eae55aebd2355f1ff4f22675dad4611960"
+  integrity sha512-IVJlVbS2dAPerPr927fEi4uXzrPXzlra5ddgyJXZZ2IKA2ZygyYWFZDM+vsQs+Vj20CfL8nOWszQQV57vdQgFg==
 
 react-native-web@0.11.1:
   version "0.11.1"
@@ -9916,11 +9916,6 @@ rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
-
-rip-out@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rip-out/-/rip-out-1.0.0.tgz#d622a7b607e1cdadc8b079bf9fb3da42c13b98e3"
-  integrity sha1-1iKntgfhza3IsHm/n7PaQsE7mOM=
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -10716,14 +10711,6 @@ svgo@^1.0.0, svgo@^1.1.1:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-swgs@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/swgs/-/swgs-3.3.0.tgz#7cc8e4a363020b50f695e1bd2d508eddae20c04b"
-  integrity sha512-OeY8i3du8Yz51P44pMXVonvF/EbqfvWEUj1NFSsNFiAM+/Ssk3CusLpScFZ2JTteW8qA8TGequKrhiT4jlTetA==
-  dependencies:
-    prop-types "^15.5.10"
-    rip-out "^1.0.0"
 
 symbol-tree@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
`react-native-svg` 9.4.0 has built-in support for `react-native-web`, so no need to use `swgs` anymore.
This change also updates `packages/svg2jsx/src/generate.ts` and regenerates all `packages/icons-md` icons.