### PR TITLE
feat(ref) add support to ref prop to access host nodes (DOM and native)

### DIFF
--- a/packages/core/src/components/app-bar/AppBar.tsx
+++ b/packages/core/src/components/app-bar/AppBar.tsx
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useContext } from 'react';
-import { ViewProps } from 'react-native';
+import React, { forwardRef, Ref, useContext } from 'react';
+import { View, ViewProps } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -60,8 +60,8 @@ export const renderAppBarCenterArea = (props: AppBarProps): React.ReactNode => {
     style: getStyleFromTheme(props, theme.centerArea),
   };
 
-  const ViewComponent = theme.centerArea && theme.centerArea.component;
-  return renderViewComponent(props, viewProps, ViewComponent);
+  const Component = theme.centerArea && theme.centerArea.component;
+  return renderViewComponent({ props, viewProps, Component });
 };
 
 export const renderAppBarLeadingArea = (
@@ -83,8 +83,8 @@ export const renderAppBarLeadingArea = (
     style: getStyleFromTheme(props, theme.leadingArea),
   };
 
-  const ViewComponent = theme.leadingArea && theme.leadingArea.component;
-  return renderViewComponent(props, viewProps, ViewComponent);
+  const Component = theme.leadingArea && theme.leadingArea.component;
+  return renderViewComponent({ props, viewProps, Component });
 };
 
 export const renderAppBarTrailingArea = (
@@ -107,8 +107,8 @@ export const renderAppBarTrailingArea = (
     style: getStyleFromTheme(props, theme.trailingArea),
   };
 
-  const ViewComponent = theme.trailingArea && theme.trailingArea.component;
-  return renderViewComponent(props, viewProps, ViewComponent);
+  const Component = theme.trailingArea && theme.trailingArea.component;
+  return renderViewComponent({ props, viewProps, Component });
 };
 
 const getTheme = (
@@ -123,36 +123,36 @@ const getTheme = (
   return componentsTheme.appBar[variant];
 };
 
-let AppBar: React.ComponentType<AppBarPropsOptional> = (
-  props: AppBarPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let AppBar: React.ComponentType<AppBarPropsOptional> = forwardRef(
+  (props: AppBarPropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: AppBarProps = {
-    ...useDefaultAppBarPropsBase(props),
-    theme,
-  };
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
+    let newProps: AppBarProps = {
+      ...useDefaultAppBarPropsBase(props),
+      theme,
+    };
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
 
-  if (Array.isArray(newProps.children) && newProps.children.length > 3) {
-    throw new Error(
-      [
-        'Rfx: SimpleAppBar.children cannot take more than 3 top-level nodes. ',
-        'You probably forgot to wrap some components into e.g. a <Row>.',
-      ].join(''),
+    if (Array.isArray(newProps.children) && newProps.children.length > 3) {
+      throw new Error(
+        [
+          'Rfx: SimpleAppBar.children cannot take more than 3 top-level nodes.',
+          'You probably forgot to wrap some components into e.g. a <Row>.',
+        ].join(' '),
+      );
+    }
+
+    return (
+      <Surface {...extractSurfacePropsFromAppBarProps(newProps)} ref={ref}>
+        {renderAppBarLeadingArea(newProps)}
+        {renderAppBarCenterArea(newProps)}
+        {renderAppBarTrailingArea(newProps)}
+      </Surface>
     );
-  }
-
-  return (
-    <Surface {...extractSurfacePropsFromAppBarProps(newProps)}>
-      {renderAppBarLeadingArea(newProps)}
-      {renderAppBarCenterArea(newProps)}
-      {renderAppBarTrailingArea(newProps)}
-    </Surface>
-  );
-};
+  },
+);
 
 AppBar = processComponent<AppBarPropsOptional>(AppBar, {
   name: 'AppBar',

--- a/packages/core/src/components/list-item/ListItem.tsx
+++ b/packages/core/src/components/list-item/ListItem.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -34,23 +35,23 @@ const getTheme = (
   return componentsTheme.listItem;
 };
 
-let ListItem: React.ComponentType<RfxViewPropsOptional> = (
-  props: RfxViewPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let ListItem: React.ComponentType<RfxViewPropsOptional> = forwardRef(
+  (props: RfxViewPropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: RfxViewProps = {
-    ...useDefaultRfxViewPropsBase(props),
-    theme,
-  };
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
-  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+    let newProps: RfxViewProps = {
+      ...useDefaultRfxViewPropsBase(props),
+      theme,
+    };
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
+    newProps = processThemeAndStyleProps(newProps, newProps.theme);
 
-  const shouldProvideColor = useShouldProvideColor(props);
-  return renderRfxViewComponent(newProps, shouldProvideColor);
-};
+    const shouldProvideColor = useShouldProvideColor(props);
+    return renderRfxViewComponent({ props: newProps, shouldProvideColor, ref });
+  },
+);
 
 ListItem = processComponent<RfxViewPropsOptional>(ListItem, {
   name: 'ListItem',

--- a/packages/core/src/components/list/List.tsx
+++ b/packages/core/src/components/list/List.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -32,24 +33,24 @@ const getTheme = (
   return componentsTheme.list;
 };
 
-let List: React.ComponentType<SurfacePropsOptional> = (
-  props: SurfacePropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let List: React.ComponentType<SurfacePropsOptional> = forwardRef(
+  (props: SurfacePropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: SurfaceProps = {
-    ...useDefaultSurfacePropsBase(props),
-    theme,
-  };
+    let newProps: SurfaceProps = {
+      ...useDefaultSurfacePropsBase(props),
+      theme,
+    };
 
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
-  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
+    newProps = processThemeAndStyleProps(newProps, newProps.theme);
 
-  const shouldProvideColor = useShouldProvideColor(newProps);
-  return renderRfxViewComponent(newProps, shouldProvideColor);
-};
+    const shouldProvideColor = useShouldProvideColor(newProps);
+    return renderRfxViewComponent({ props: newProps, shouldProvideColor, ref });
+  },
+);
 
 List = processComponent<SurfacePropsOptional>(List, {
   name: 'List',

--- a/packages/core/src/components/screen/Screen.tsx
+++ b/packages/core/src/components/screen/Screen.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -31,24 +32,24 @@ const getTheme = (
   return componentsTheme.screen;
 };
 
-let Screen: React.ComponentType<SurfacePropsOptional> = (
-  props: SurfacePropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Screen: React.ComponentType<SurfacePropsOptional> = forwardRef(
+  (props: SurfacePropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: SurfaceProps = {
-    ...useDefaultScreenPropsBase(props),
-    theme,
-  };
+    let newProps: SurfaceProps = {
+      ...useDefaultScreenPropsBase(props),
+      theme,
+    };
 
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
-  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
+    newProps = processThemeAndStyleProps(newProps, newProps.theme);
 
-  const shouldProvideColor = useShouldProvideColor(newProps);
-  return renderRfxViewComponent(newProps, shouldProvideColor);
-};
+    const shouldProvideColor = useShouldProvideColor(newProps);
+    return renderRfxViewComponent({ props: newProps, shouldProvideColor, ref });
+  },
+);
 
 Screen = processComponent<SurfacePropsOptional>(Screen, {
   name: 'Screen',

--- a/packages/core/src/components/surface/Surface.tsx
+++ b/packages/core/src/components/surface/Surface.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -34,23 +35,23 @@ const getTheme = (
   return componentsTheme.surface;
 };
 
-let Surface: React.ComponentType<SurfacePropsOptional> = (
-  props: SurfacePropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Surface: React.ComponentType<SurfacePropsOptional> = forwardRef(
+  (props: SurfacePropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: SurfaceProps = {
-    ...useDefaultSurfacePropsBase(props),
-    theme,
-  };
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
-  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+    let newProps: SurfaceProps = {
+      ...useDefaultSurfacePropsBase(props),
+      theme,
+    };
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
+    newProps = processThemeAndStyleProps(newProps, newProps.theme);
 
-  const shouldProvideColor = useShouldProvideColor(newProps);
-  return renderRfxViewComponent(newProps, shouldProvideColor);
-};
+    const shouldProvideColor = useShouldProvideColor(newProps);
+    return renderRfxViewComponent({ props: newProps, shouldProvideColor, ref });
+  },
+);
 
 Surface = processComponent<SurfacePropsOptional>(Surface, {
   name: 'Surface',

--- a/packages/core/src/components/text/AppBarTitle.tsx
+++ b/packages/core/src/components/text/AppBarTitle.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.appBarTitle;
 };
 
-let AppBarTitle: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let AppBarTitle: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 AppBarTitle = processComponent<RfxTextPropsOptional>(AppBarTitle, {
   name: 'AppBarTitle',

--- a/packages/core/src/components/text/Caption.tsx
+++ b/packages/core/src/components/text/Caption.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.caption;
 };
 
-let Caption: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Caption: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Caption = processComponent<RfxTextPropsOptional>(Caption, {
   name: 'Caption',

--- a/packages/core/src/components/text/Headline1.tsx
+++ b/packages/core/src/components/text/Headline1.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.headline1;
 };
 
-let Headline1: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Headline1: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Headline1 = processComponent<RfxTextPropsOptional>(Headline1, {
   name: 'Headline1',

--- a/packages/core/src/components/text/Headline2.tsx
+++ b/packages/core/src/components/text/Headline2.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.headline2;
 };
 
-let Headline2: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Headline2: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Headline2 = processComponent<RfxTextPropsOptional>(Headline2, {
   name: 'Headline2',

--- a/packages/core/src/components/text/Headline3.tsx
+++ b/packages/core/src/components/text/Headline3.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.headline3;
 };
 
-let Headline3: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Headline3: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Headline3 = processComponent<RfxTextPropsOptional>(Headline3, {
   name: 'Headline3',

--- a/packages/core/src/components/text/Headline4.tsx
+++ b/packages/core/src/components/text/Headline4.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.headline4;
 };
 
-let Headline4: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Headline4: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Headline4 = processComponent<RfxTextPropsOptional>(Headline4, {
   name: 'Headline4',

--- a/packages/core/src/components/text/Headline5.tsx
+++ b/packages/core/src/components/text/Headline5.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.headline5;
 };
 
-let Headline5: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Headline5: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Headline5 = processComponent<RfxTextPropsOptional>(Headline5, {
   name: 'Headline5',

--- a/packages/core/src/components/text/Headline6.tsx
+++ b/packages/core/src/components/text/Headline6.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.headline6;
 };
 
-let Headline6: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Headline6: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Headline6 = processComponent<RfxTextPropsOptional>(Headline6, {
   name: 'Headline6',

--- a/packages/core/src/components/text/Overline.tsx
+++ b/packages/core/src/components/text/Overline.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.overline;
 };
 
-let Overline: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Overline: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Overline = processComponent<RfxTextPropsOptional>(Overline, {
   name: 'Overline',

--- a/packages/core/src/components/text/Paragraph1.tsx
+++ b/packages/core/src/components/text/Paragraph1.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.paragraph1;
 };
 
-let Paragraph1: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Paragraph1: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Paragraph1 = processComponent<RfxTextPropsOptional>(Paragraph1, {
   name: 'Paragraph1',

--- a/packages/core/src/components/text/Paragraph2.tsx
+++ b/packages/core/src/components/text/Paragraph2.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.paragraph2;
 };
 
-let Paragraph2: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Paragraph2: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Paragraph2 = processComponent<RfxTextPropsOptional>(Paragraph2, {
   name: 'Paragraph2',

--- a/packages/core/src/components/text/RfxTextProps.ts
+++ b/packages/core/src/components/text/RfxTextProps.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { TextProps } from 'react-native';
+import { Ref } from 'react';
+import { Text, TextProps } from 'react-native';
 
 import { ColorProps } from '../../color/ColorProps';
 import { FlexboxProps } from '../../flexbox/FlexboxProps';
@@ -27,7 +28,9 @@ export interface RfxTextPropsBase
     MarginProps,
     OnLayoutProps,
     PaddingProps,
-    TextProps {}
+    TextProps {
+  readonly ref?: Ref<Text>;
+}
 
 export type RfxTextPropsBaseOptional = Partial<RfxTextPropsBase>;
 

--- a/packages/core/src/components/text/Subtitle1.tsx
+++ b/packages/core/src/components/text/Subtitle1.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.subtitle1;
 };
 
-let Subtitle1: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Subtitle1: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Subtitle1 = processComponent<RfxTextPropsOptional>(Subtitle1, {
   name: 'Subtitle1',

--- a/packages/core/src/components/text/Subtitle2.tsx
+++ b/packages/core/src/components/text/Subtitle2.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { Text } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -28,20 +29,20 @@ const getTheme = (
   return componentsTheme.text.subtitle2;
 };
 
-let Subtitle2: React.ComponentType<RfxTextPropsOptional> = (
-  props: RfxTextPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Subtitle2: React.ComponentType<RfxTextPropsOptional> = forwardRef(
+  (props: RfxTextPropsOptional, ref: Ref<Text>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  const newProps: RfxTextProps = {
-    ...useDefaultRfxTextPropsBase(props),
-    ...useOnLayout(props),
-    theme,
-  };
+    const newProps: RfxTextProps = {
+      ...useDefaultRfxTextPropsBase(props),
+      ...useOnLayout(props),
+      theme,
+    };
 
-  return renderRfxTextComponent(newProps);
-};
+    return renderRfxTextComponent(newProps, ref);
+  },
+);
 
 Subtitle2 = processComponent<RfxTextPropsOptional>(Subtitle2, {
   name: 'Subtitle2',

--- a/packages/core/src/components/text/renderRfxTextComponent.ts
+++ b/packages/core/src/components/text/renderRfxTextComponent.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as React from 'react';
+import React, { Ref } from 'react';
+import { Text } from 'react-native';
 
 import { extractTextProps } from '../../utils/props';
 import { processComponentProps } from '../processComponentProps';
@@ -15,6 +16,7 @@ import { RfxTextProps } from './RfxTextProps';
 
 export const renderRfxTextComponent = (
   props: RfxTextProps,
+  ref: Ref<Text>,
 ): React.ReactElement | null => {
   let newProps = processComponentProps(props);
   newProps = processThemeAndStyleProps(newProps, newProps.theme);
@@ -28,11 +30,12 @@ export const renderRfxTextComponent = (
     typeof children === 'boolean' ||
     Array.isArray(children)
   ) {
+    const Component = newProps.theme.component;
     const textProps = {
       ...extractTextProps(newProps),
       children,
     };
-    return renderTextComponent(newProps, textProps, newProps.theme.component);
+    return renderTextComponent({ Component, props: newProps, ref, textProps });
   }
 
   if ('type' in children) return children;

--- a/packages/core/src/components/text/renderTextComponent.tsx
+++ b/packages/core/src/components/text/renderTextComponent.tsx
@@ -5,19 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as React from 'react';
+import React, { Ref } from 'react';
 import { Text, TextProps } from 'react-native';
 
 import { BuiltInSimpleComponentProps } from '../BuiltInSimpleComponentProps';
 
-export const renderTextComponent = <ComponentProps extends {}>(
-  props: ComponentProps,
-  textProps: TextProps & Readonly<{ children?: React.ReactNode }>,
-  Component:
+export interface TextComponentRendererInput<ComponentProps> {
+  Component?:
     | typeof Text
     | React.ComponentType<BuiltInSimpleComponentProps<ComponentProps>> &
-        TextProps = Text,
+        TextProps;
+  props: ComponentProps;
+  ref?: Ref<Text>;
+  textProps: TextProps & Readonly<{ children?: React.ReactNode }>;
+}
+
+export const renderTextComponent = <ComponentProps extends {}>(
+  input: TextComponentRendererInput<ComponentProps>,
 ): JSX.Element => {
-  if (Component === Text) return <Component {...textProps} />;
+  const { Component, props, ref, textProps } = input;
+  if (Component === undefined || Component === Text) {
+    return <Text {...textProps} ref={ref} />;
+  }
   return <Component complexComponentProps={props} {...textProps} />;
 };

--- a/packages/core/src/components/touchable-surface/TouchableSurface.tsx
+++ b/packages/core/src/components/touchable-surface/TouchableSurface.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import React, { useContext } from 'react';
+import React, { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { InteractionStateContext } from '../../interaction';
@@ -63,9 +64,9 @@ const getTheme = (
   return componentsTheme.touchableSurface;
 };
 
-let TouchableSurface: React.ComponentType<TouchableSurfacePropsOptional> = (
-  props: TouchableSurfacePropsOptional,
-) => {
+let TouchableSurface: React.ComponentType<
+  TouchableSurfacePropsOptional
+> = forwardRef((props: TouchableSurfacePropsOptional, ref: Ref<View>) => {
   const componentsTheme = useContext(ComponentsThemeContext);
   const theme = getTheme(props, componentsTheme);
 
@@ -82,7 +83,11 @@ let TouchableSurface: React.ComponentType<TouchableSurfacePropsOptional> = (
     newProps.theme.touchable && newProps.theme.touchable.component;
 
   const surfaceProps = extractSurfacePropsFromTouchableSurfaceProps(newProps);
-  const surface = <Surface {...surfaceProps}>{newProps.children}</Surface>;
+  const surface = (
+    <Surface {...surfaceProps} ref={ref}>
+      {newProps.children}
+    </Surface>
+  );
   newProps = { ...newProps, children: surface };
 
   return (
@@ -90,7 +95,7 @@ let TouchableSurface: React.ComponentType<TouchableSurfacePropsOptional> = (
       {renderTouchableComponent(newProps, Touchable)}
     </InteractionStateContext.Provider>
   );
-};
+});
 
 TouchableSurface = processComponent<TouchableSurfacePropsOptional>(
   TouchableSurface,

--- a/packages/core/src/components/view/Column.tsx
+++ b/packages/core/src/components/view/Column.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -31,23 +32,23 @@ const getTheme = (
   return componentsTheme.views.column;
 };
 
-let Column: React.ComponentType<RfxViewPropsOptional> = (
-  props: RfxViewPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Column: React.ComponentType<RfxViewPropsOptional> = forwardRef(
+  (props: RfxViewPropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: RfxViewProps = {
-    ...useDefaultRfxViewPropsBase(props),
-    theme,
-  };
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
-  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+    let newProps: RfxViewProps = {
+      ...useDefaultRfxViewPropsBase(props),
+      theme,
+    };
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
+    newProps = processThemeAndStyleProps(newProps, newProps.theme);
 
-  const shouldProvideColor = useShouldProvideColor(props);
-  return renderRfxViewComponent(newProps, shouldProvideColor);
-};
+    const shouldProvideColor = useShouldProvideColor(props);
+    return renderRfxViewComponent({ props: newProps, shouldProvideColor, ref });
+  },
+);
 
 Column = processComponent<RfxViewPropsOptional>(Column, {
   name: 'Column',

--- a/packages/core/src/components/view/RfxViewProps.ts
+++ b/packages/core/src/components/view/RfxViewProps.ts
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { ViewProps } from 'react-native';
+import { Ref } from 'react';
+import { View, ViewProps } from 'react-native';
 
 import { ColorProps } from '../../color/ColorProps';
 import { FlexboxProps } from '../../flexbox/FlexboxProps';
@@ -39,7 +40,9 @@ export interface RfxViewPropsBase
     OnLayoutProps,
     PaddingProps,
     SizingPropsOptional,
-    ViewProps {}
+    ViewProps {
+  readonly ref?: Ref<View>;
+}
 
 export type RfxViewPropsBaseOptional = Partial<RfxViewPropsBase>;
 

--- a/packages/core/src/components/view/Row.tsx
+++ b/packages/core/src/components/view/Row.tsx
@@ -5,7 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { useContext } from 'react';
+import { forwardRef, Ref, useContext } from 'react';
+import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
@@ -31,23 +32,23 @@ const getTheme = (
   return componentsTheme.views.row;
 };
 
-let Row: React.ComponentType<RfxViewPropsOptional> = (
-  props: RfxViewPropsOptional,
-) => {
-  const componentsTheme = useContext(ComponentsThemeContext);
-  const theme = getTheme(props, componentsTheme);
+let Row: React.ComponentType<RfxViewPropsOptional> = forwardRef(
+  (props: RfxViewPropsOptional, ref: Ref<View>) => {
+    const componentsTheme = useContext(ComponentsThemeContext);
+    const theme = getTheme(props, componentsTheme);
 
-  let newProps: RfxViewProps = {
-    ...useDefaultRfxViewPropsBase(props),
-    theme,
-  };
-  newProps = { ...newProps, ...useOnLayout(newProps) };
-  newProps = processComponentProps(newProps);
-  newProps = processThemeAndStyleProps(newProps, newProps.theme);
+    let newProps: RfxViewProps = {
+      ...useDefaultRfxViewPropsBase(props),
+      theme,
+    };
+    newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = processComponentProps(newProps);
+    newProps = processThemeAndStyleProps(newProps, newProps.theme);
 
-  const shouldProvideColor = useShouldProvideColor(props);
-  return renderRfxViewComponent(newProps, shouldProvideColor);
-};
+    const shouldProvideColor = useShouldProvideColor(props);
+    return renderRfxViewComponent({ props: newProps, shouldProvideColor, ref });
+  },
+);
 
 Row = processComponent<RfxViewPropsOptional>(Row, {
   name: 'Row',

--- a/packages/core/src/components/view/renderRfxViewComponent.tsx
+++ b/packages/core/src/components/view/renderRfxViewComponent.tsx
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as React from 'react';
-import { ViewProps } from 'react-native';
+import React, { Ref } from 'react';
+import { View, ViewProps } from 'react-native';
 
 import { PaletteColorContext } from '../../color/PaletteColorContext';
 import { extractViewProps } from '../../utils/props';
@@ -16,21 +16,32 @@ import { BuiltInSimpleComponentTheme } from '../SimpleComponentTheme';
 import { renderViewComponent } from './renderViewComponent';
 import { RfxViewPropsBase } from './RfxViewProps';
 
+export interface RfxViewComponentRendererInput<Props> {
+  readonly props: Props;
+  readonly ref?: Ref<View>;
+  readonly shouldProvideColor?: boolean;
+}
+
 export const renderRfxViewComponent = <
   Props extends RfxViewPropsBase &
     ComponentThemeProps<Props, Theme> &
     ComponentChildrenProps<Props>,
   Theme extends BuiltInSimpleComponentTheme<Props, unknown, unknown>
 >(
-  props: Props,
-  shouldProvideColor: boolean = false,
+  input: RfxViewComponentRendererInput<Props>,
 ): React.ReactElement => {
+  const { props, ref, shouldProvideColor } = input;
   const { children, paletteColor, theme } = props;
   const viewProps: React.PropsWithChildren<ViewProps> = {
     ...extractViewProps(props),
     children,
   };
-  const renderedView = renderViewComponent(props, viewProps, theme.component);
+  const renderedView = renderViewComponent({
+    Component: theme.component,
+    props,
+    ref,
+    viewProps,
+  });
 
   if (shouldProvideColor) {
     return (

--- a/packages/core/src/components/view/renderViewComponent.tsx
+++ b/packages/core/src/components/view/renderViewComponent.tsx
@@ -5,19 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as React from 'react';
+import React, { Ref } from 'react';
 import { View, ViewProps } from 'react-native';
 
 import { BuiltInSimpleComponentProps } from '../BuiltInSimpleComponentProps';
 
-export const renderViewComponent = <ComponentProps extends {}>(
-  props: ComponentProps,
-  viewProps: ViewProps & Readonly<{ children?: React.ReactNode }>,
-  Component:
+export interface ViewComponentRendererInput<ComponentProps> {
+  readonly Component?:
     | typeof View
     | React.ComponentType<BuiltInSimpleComponentProps<ComponentProps>> &
-        ViewProps = View,
+        ViewProps;
+  readonly props: ComponentProps;
+  readonly ref?: Ref<View>;
+  readonly viewProps: ViewProps & Readonly<{ children?: React.ReactNode }>;
+}
+
+export const renderViewComponent = <ComponentProps extends {}>(
+  input: ViewComponentRendererInput<ComponentProps>,
 ): JSX.Element => {
-  if (Component === View) return <Component {...viewProps} />;
+  const { Component, props, ref, viewProps } = input;
+  if (Component === undefined || Component === View) {
+    return <View {...viewProps} ref={ref} />;
+  }
   return <Component complexComponentProps={props} {...viewProps} />;
 };


### PR DESCRIPTION
Add support to ref prop to access host nodes (DOM or native) to all components except Svg ones (`RfxSvg`, `RfxSvgIcon`, and `icons-md`).