### PR TITLE
refactor(color) make it easier to create FlexColor objects

### DIFF
--- a/packages/core-md/src/color/MdFlexColorFactoryInput.ts
+++ b/packages/core-md/src/color/MdFlexColorFactoryInput.ts
@@ -5,18 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { LayeredColor } from './LayeredColor';
-import { LayeredColorFactory } from './LayeredColorFactory';
+import { LayeredColor, LayeredColorFactory } from '@reflex-ui/core';
 
-export interface FlexColorFactoryInput {
+export interface MdFlexColorFactoryInput {
   readonly containedColor: LayeredColor;
   readonly containedColorDisabled: LayeredColor;
-  readonly containedColorFactory: LayeredColorFactory;
+  readonly containedColorFactory?: LayeredColorFactory;
   readonly containedInvertedColor?: LayeredColor;
   readonly containedInvertedColorDisabled: LayeredColor;
   readonly uncontainedColor?: LayeredColor;
   readonly uncontainedColorDisabled: LayeredColor;
-  readonly uncontainedColorFactory: LayeredColorFactory;
+  readonly uncontainedColorFactory?: LayeredColorFactory;
   readonly uncontainedInvertedColor?: LayeredColor;
   readonly uncontainedInvertedColorDisabled: LayeredColor;
 }

--- a/packages/core-md/src/color/colors/black/mdBlack.ts
+++ b/packages/core-md/src/color/colors/black/mdBlack.ts
@@ -5,18 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  LayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { LayeredColor, PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -31,18 +22,11 @@ const blackLayeredColor: LayeredColor = {
 };
 
 export const mdBlack: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: blackLayeredColor,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(blackLayeredColor),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(blackLayeredColor),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(
-      blackLayeredColor,
-    ),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Black',

--- a/packages/core-md/src/color/colors/blue/mdBlue500.ts
+++ b/packages/core-md/src/color/colors/blue/mdBlue500.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey400Uncontained,
@@ -25,16 +17,11 @@ import {
 import { blue500, blue500Dark, blue500Light } from './blue500';
 
 export const mdBlue500: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: blue500,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(blue500),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(blue500),
     uncontainedColorDisabled: disabledGrey400Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(blue500),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Blue',
@@ -42,16 +29,11 @@ export const mdBlue500: PaletteColor = {
 };
 
 export const mdBlue500Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: blue500Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(blue500Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(blue500Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(blue500Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Blue',
@@ -59,16 +41,11 @@ export const mdBlue500Dark: PaletteColor = {
 };
 
 export const mdBlue500Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: blue500Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(blue500Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(blue500Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(blue500Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Blue',

--- a/packages/core-md/src/color/colors/deepPurple/mdDeepPurple500.ts
+++ b/packages/core-md/src/color/colors/deepPurple/mdDeepPurple500.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey400Uncontained,
@@ -28,16 +20,11 @@ import {
 } from './deepPurple500';
 
 export const mdDeepPurple500: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: deepPurple500,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(deepPurple500),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(deepPurple500),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(deepPurple500),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Deep Purple',
@@ -45,18 +32,11 @@ export const mdDeepPurple500: PaletteColor = {
 };
 
 export const mdDeepPurple500Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: deepPurple500Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(deepPurple500Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(deepPurple500Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(
-      deepPurple500Dark,
-    ),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Deep Purple',
@@ -64,18 +44,11 @@ export const mdDeepPurple500Dark: PaletteColor = {
 };
 
 export const mdDeepPurple500Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: deepPurple500Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(deepPurple500Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(deepPurple500Light),
     uncontainedColorDisabled: disabledGrey400Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(
-      deepPurple500Light,
-    ),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Deep Purple',

--- a/packages/core-md/src/color/colors/green/mdGreen800.ts
+++ b/packages/core-md/src/color/colors/green/mdGreen800.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { green800, green800Dark, green800Light } from './green800';
 
 export const mdGreen800: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: green800,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(green800),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(green800),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(green800),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Green',
@@ -41,16 +28,11 @@ export const mdGreen800: PaletteColor = {
 };
 
 export const mdGreen800Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: green800Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(green800Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(green800Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(green800Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Green',
@@ -58,16 +40,11 @@ export const mdGreen800Dark: PaletteColor = {
 };
 
 export const mdGreen800Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: green800Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(green800Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(green800Light),
     uncontainedColorDisabled: disabledGrey700Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(green800Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Green',

--- a/packages/core-md/src/color/colors/grey/mdGrey100.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey100.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey100, grey100Dark, grey100Light } from './grey100';
 
 export const mdGrey100: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey100,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey100),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey100),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey100),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey100: PaletteColor = {
 };
 
 export const mdGrey100Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey100Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey100Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey100Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey100Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey100Dark: PaletteColor = {
 };
 
 export const mdGrey100Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey100Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey100Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey100Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey100Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey200.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey200.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey200, grey200Dark, grey200Light } from './grey200';
 
 export const mdGrey200: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey200,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey200),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey200),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey200),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey200: PaletteColor = {
 };
 
 export const mdGrey200Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey200Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey200Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey200Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey200Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey200Dark: PaletteColor = {
 };
 
 export const mdGrey200Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey200Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey200Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey200Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey200Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey300.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey300.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey300, grey300Dark, grey300Light } from './grey300';
 
 export const mdGrey300: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey300,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey300),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey300),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey300),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey300: PaletteColor = {
 };
 
 export const mdGrey300Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey300Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey300Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey300Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey300Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey300Dark: PaletteColor = {
 };
 
 export const mdGrey300Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey300Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey300Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey300Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey300Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey400.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey400.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey400, grey400Dark, grey400Light } from './grey400';
 
 export const mdGrey400: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey400,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey400),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey400),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey400),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey400: PaletteColor = {
 };
 
 export const mdGrey400Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey400Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey400Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey400Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey400Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey400Dark: PaletteColor = {
 };
 
 export const mdGrey400Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey400Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey400Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey400Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey400Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey50.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey50.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey50, grey50Dark, grey50Light } from './grey50';
 
 export const mdGrey50: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey50,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey50),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey50),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey50),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey50: PaletteColor = {
 };
 
 export const mdGrey50Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey50Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey50Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey50Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey50Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey50Dark: PaletteColor = {
 };
 
 export const mdGrey50Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey50Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey50Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey50Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey50Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey500.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey500.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey500, grey500Dark, grey500Light } from './grey500';
 
 export const mdGrey500: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey500,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey500),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey500),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey500),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey500: PaletteColor = {
 };
 
 export const mdGrey500Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey500Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey500Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey500Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey500Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey500Dark: PaletteColor = {
 };
 
 export const mdGrey500Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey500Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey500Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey500Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey500Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey600.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey600.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey600, grey600Dark, grey600Light } from './grey600';
 
 export const mdGrey600: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey600,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey600),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey600),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey600),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey600: PaletteColor = {
 };
 
 export const mdGrey600Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey600Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey600Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey600Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey600Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey600Dark: PaletteColor = {
 };
 
 export const mdGrey600Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey600Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey600Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey600Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey600Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey700.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey700.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey700, grey700Dark, grey700Light } from './grey700';
 
 export const mdGrey700: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey700,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey700),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey700),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey700),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey700: PaletteColor = {
 };
 
 export const mdGrey700Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey700Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey700Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey700Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey700Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey700Dark: PaletteColor = {
 };
 
 export const mdGrey700Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey700Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey700Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey700Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey700Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey800.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey800.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey800, grey800Dark, grey800Light } from './grey800';
 
 export const mdGrey800: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey800,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey800),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey800),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey800),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey800: PaletteColor = {
 };
 
 export const mdGrey800Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey800Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey800Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey800Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey800Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey800Dark: PaletteColor = {
 };
 
 export const mdGrey800Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey800Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey800Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey800Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey800Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/grey/mdGrey900.ts
+++ b/packages/core-md/src/color/colors/grey/mdGrey900.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { grey900, grey900Dark, grey900Light } from './grey900';
 
 export const mdGrey900: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey900,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey900),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey900),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey900),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -41,16 +28,11 @@ export const mdGrey900: PaletteColor = {
 };
 
 export const mdGrey900Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey900Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey900Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey900Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey900Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',
@@ -58,16 +40,11 @@ export const mdGrey900Dark: PaletteColor = {
 };
 
 export const mdGrey900Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: grey900Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(grey900Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(grey900Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(grey900Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Grey',

--- a/packages/core-md/src/color/colors/orange/mdOrange600.ts
+++ b/packages/core-md/src/color/colors/orange/mdOrange600.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey400Uncontained,
@@ -25,16 +17,11 @@ import {
 import { orange600, orange600Dark, orange600Light } from './orange600';
 
 export const mdOrange600: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: orange600,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(orange600),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(orange600),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(orange600),
     uncontainedInvertedColorDisabled: disabledGrey400Uncontained,
   }),
   name: 'Orange',
@@ -42,16 +29,11 @@ export const mdOrange600: PaletteColor = {
 };
 
 export const mdOrange600Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: orange600Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(orange600Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(orange600Dark),
     uncontainedColorDisabled: disabledGrey400Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(orange600Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Orange',
@@ -59,16 +41,11 @@ export const mdOrange600Dark: PaletteColor = {
 };
 
 export const mdOrange600Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: orange600Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(orange600Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(orange600Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(orange600Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Orange',

--- a/packages/core-md/src/color/colors/red/mdRed900.ts
+++ b/packages/core-md/src/color/colors/red/mdRed900.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { red900, red900Dark, red900Light } from './red900';
 
 export const mdRed900: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: red900,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(red900),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(red900),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(red900),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Red',
@@ -41,16 +28,11 @@ export const mdRed900: PaletteColor = {
 };
 
 export const mdRed900Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: red900Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(red900Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(red900Dark),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(red900Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Red',
@@ -58,16 +40,11 @@ export const mdRed900Dark: PaletteColor = {
 };
 
 export const mdRed900Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: red900Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(red900Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(red900Light),
     uncontainedColorDisabled: disabledGrey700Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(red900Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Red',

--- a/packages/core-md/src/color/colors/teal/mdTealA700.ts
+++ b/packages/core-md/src/color/colors/teal/mdTealA700.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey400Uncontained,
@@ -25,16 +17,11 @@ import {
 import { tealA700, tealA700Dark, tealA700Light } from './tealA700';
 
 export const mdTealA700: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: tealA700,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(tealA700),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(tealA700),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(tealA700),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Teal',
@@ -42,16 +29,11 @@ export const mdTealA700: PaletteColor = {
 };
 
 export const mdTealA700Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: tealA700Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(tealA700Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(tealA700Dark),
     uncontainedColorDisabled: disabledGrey400Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(tealA700Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Teal',
@@ -59,16 +41,11 @@ export const mdTealA700Dark: PaletteColor = {
 };
 
 export const mdTealA700Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: tealA700Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(tealA700Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(tealA700Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(tealA700Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Teal',

--- a/packages/core-md/src/color/colors/white/mdWhite.ts
+++ b/packages/core-md/src/color/colors/white/mdWhite.ts
@@ -5,18 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  LayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { LayeredColor, PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { black } from '../black/black';
 import { disabledGrey300Contained } from '../disabled/contained';
 import { disabledGrey500Uncontained } from '../disabled/uncontained';
@@ -28,18 +19,11 @@ const whiteLayeredColor: LayeredColor = {
 };
 
 export const mdWhite: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: whiteLayeredColor,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(whiteLayeredColor),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(whiteLayeredColor),
     uncontainedColorDisabled: disabledGrey500Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(
-      whiteLayeredColor,
-    ),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'White',

--- a/packages/core-md/src/color/colors/yellow/mdYellow600.ts
+++ b/packages/core-md/src/color/colors/yellow/mdYellow600.ts
@@ -5,17 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  createFlexColor,
-  createLayeredColorUsingColorOnly,
-  createLayeredColorUsingOnColorOnly,
-  invertLayeredColor,
-  PaletteColor,
-} from '@reflex-ui/core';
+import { PaletteColor } from '@reflex-ui/core';
 
-import { createContainedLayeredColor } from '../../createContainedLayeredColor';
-// tslint:disable-next-line:max-line-length
-import { createUncontainedLayeredColor } from '../../createUncontainedLayeredColor';
+import { createMdFlexColor } from '../../createMdFlexColor';
 import { disabledGrey300Contained } from '../disabled/contained';
 import {
   disabledGrey500Uncontained,
@@ -24,16 +16,11 @@ import {
 import { yellow600, yellow600Dark, yellow600Light } from './yellow600';
 
 export const mdYellow600: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: yellow600,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(yellow600),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(yellow600),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(yellow600),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Yellow',
@@ -41,16 +28,11 @@ export const mdYellow600: PaletteColor = {
 };
 
 export const mdYellow600Dark: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: yellow600Dark,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(yellow600Dark),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(yellow600Dark),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(yellow600Dark),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Yellow',
@@ -58,16 +40,11 @@ export const mdYellow600Dark: PaletteColor = {
 };
 
 export const mdYellow600Light: PaletteColor = {
-  color: createFlexColor({
+  color: createMdFlexColor({
     containedColor: yellow600Light,
     containedColorDisabled: disabledGrey300Contained,
-    containedColorFactory: createContainedLayeredColor,
-    containedInvertedColor: invertLayeredColor(yellow600Light),
     containedInvertedColorDisabled: disabledGrey300Contained,
-    uncontainedColor: createLayeredColorUsingOnColorOnly(yellow600Light),
     uncontainedColorDisabled: disabledGrey600Uncontained,
-    uncontainedColorFactory: createUncontainedLayeredColor,
-    uncontainedInvertedColor: createLayeredColorUsingColorOnly(yellow600Light),
     uncontainedInvertedColorDisabled: disabledGrey500Uncontained,
   }),
   name: 'Yellow',

--- a/packages/core-md/src/color/createMdFlexColor.ts
+++ b/packages/core-md/src/color/createMdFlexColor.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  createFlexColor as createFlexColorCore,
+  FlexColor,
+} from '@reflex-ui/core';
+
+import { disabledGrey300Contained } from './colors/disabled/contained';
+import {
+  disabledGrey400Uncontained,
+  disabledGrey500Uncontained,
+} from './colors/disabled/uncontained';
+import { createContainedLayeredColor } from './createContainedLayeredColor';
+import { createUncontainedLayeredColor } from './createUncontainedLayeredColor';
+import { MdFlexColorFactoryInput } from './MdFlexColorFactoryInput';
+
+export const createMdFlexColor = ({
+  containedColor,
+  containedColorDisabled = disabledGrey300Contained,
+  containedColorFactory = createContainedLayeredColor,
+  containedInvertedColor,
+  containedInvertedColorDisabled = disabledGrey300Contained,
+  uncontainedColor,
+  uncontainedColorDisabled = disabledGrey400Uncontained,
+  uncontainedColorFactory = createUncontainedLayeredColor,
+  uncontainedInvertedColor,
+  uncontainedInvertedColorDisabled = disabledGrey500Uncontained,
+}: MdFlexColorFactoryInput): FlexColor =>
+  createFlexColorCore({
+    containedColor,
+    containedColorDisabled,
+    containedColorFactory,
+    containedInvertedColor,
+    containedInvertedColorDisabled,
+    uncontainedColor,
+    uncontainedColorDisabled,
+    uncontainedColorFactory,
+    uncontainedInvertedColor,
+    uncontainedInvertedColorDisabled,
+  });

--- a/packages/core-md/src/color/index.ts
+++ b/packages/core-md/src/color/index.ts
@@ -6,9 +6,11 @@
  */
 
 export * from './createContainedLayeredColor';
+export * from './createMdFlexColor';
 export * from './createUncontainedLayeredColor';
 export * from './ColorByInteractionGetterInput';
 export * from './colors';
 export * from './getInlayColorByInteraction';
 export * from './getOverlayColorByInteraction';
+export * from './MdFlexColorFactoryInput';
 export * from './palettes';

--- a/packages/core/src/color/ColorGamutFactoryInput.ts
+++ b/packages/core/src/color/ColorGamutFactoryInput.ts
@@ -5,18 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { InteractionType } from '../interaction/InteractionType';
 import { LayeredColor } from './LayeredColor';
 import { LayeredColorFactory } from './LayeredColorFactory';
 
-export interface FlexColorFactoryInput {
+export interface ColorGamutFactoryInput {
   readonly containedColor: LayeredColor;
-  readonly containedColorDisabled: LayeredColor;
   readonly containedColorFactory: LayeredColorFactory;
-  readonly containedInvertedColor?: LayeredColor;
-  readonly containedInvertedColorDisabled: LayeredColor;
-  readonly uncontainedColor?: LayeredColor;
-  readonly uncontainedColorDisabled: LayeredColor;
+  readonly containedInvertedColor: LayeredColor;
+  readonly interactionType: InteractionType;
+  readonly uncontainedColor: LayeredColor;
   readonly uncontainedColorFactory: LayeredColorFactory;
-  readonly uncontainedInvertedColor?: LayeredColor;
-  readonly uncontainedInvertedColorDisabled: LayeredColor;
+  readonly uncontainedInvertedColor: LayeredColor;
 }

--- a/packages/core/src/color/createColorGamut.ts
+++ b/packages/core/src/color/createColorGamut.ts
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { ColorGamut } from './ColorGamut';
+import { ColorGamutFactoryInput } from './ColorGamutFactoryInput';
+
+export const createColorGamut = (
+  config: ColorGamutFactoryInput,
+): ColorGamut => ({
+  contained: config.containedColorFactory({
+    color: config.containedColor,
+    interactionType: config.interactionType,
+  }),
+  containedInverted: config.containedColorFactory({
+    color: config.containedInvertedColor,
+    interactionType: config.interactionType,
+  }),
+  uncontained: config.uncontainedColorFactory({
+    color: config.uncontainedColor,
+    interactionType: config.interactionType,
+  }),
+  uncontainedInverted: config.uncontainedColorFactory({
+    color: config.uncontainedInvertedColor,
+    interactionType: config.interactionType,
+  }),
+});

--- a/packages/core/src/color/createFlexColor.ts
+++ b/packages/core/src/color/createFlexColor.ts
@@ -6,93 +6,76 @@
  */
 
 import { InteractionType } from '../interaction/InteractionType';
-import { ColorGamut } from './ColorGamut';
+import { createColorGamut } from './createColorGamut';
+// tslint:disable-next-line:max-line-length
+import { createLayeredColorUsingColorOnly } from './createLayeredColorUsingColorOnly';
+// tslint:disable-next-line:max-line-length
+import { createLayeredColorUsingOnColorOnly } from './createLayeredColorUsingOnColorOnly';
 import { FlexColor } from './FlexColor';
 import { FlexColorFactoryInput } from './FlexColorFactoryInput';
-import { LayeredColor } from './LayeredColor';
-import { LayeredColorFactory } from './LayeredColorFactory';
+import { invertLayeredColor } from './invertLayeredColor';
 
-export interface ColorGamutFactoryInput {
-  readonly containedColor: LayeredColor;
-  readonly containedColorFactory: LayeredColorFactory;
-  readonly containedInvertedColor: LayeredColor;
-  readonly interactionType: InteractionType;
-  readonly uncontainedColor: LayeredColor;
-  readonly uncontainedColorFactory: LayeredColorFactory;
-  readonly uncontainedInvertedColor: LayeredColor;
-}
-
-export const createColorGamut = (
-  config: ColorGamutFactoryInput,
-): ColorGamut => ({
-  contained: config.containedColorFactory({
-    color: config.containedColor,
-    interactionType: config.interactionType,
-  }),
-  containedInverted: config.containedColorFactory({
-    color: config.containedInvertedColor,
-    interactionType: config.interactionType,
-  }),
-  uncontained: config.uncontainedColorFactory({
-    color: config.uncontainedColor,
-    interactionType: config.interactionType,
-  }),
-  uncontainedInverted: config.uncontainedColorFactory({
-    color: config.uncontainedInvertedColor,
-    interactionType: config.interactionType,
-  }),
-});
-
-export const createFlexColor = (config: FlexColorFactoryInput): FlexColor => ({
+export const createFlexColor = ({
+  containedColor,
+  containedColorDisabled,
+  containedColorFactory,
+  containedInvertedColor = invertLayeredColor(containedColor),
+  containedInvertedColorDisabled,
+  uncontainedColor = createLayeredColorUsingOnColorOnly(containedColor),
+  uncontainedColorDisabled,
+  uncontainedColorFactory,
+  uncontainedInvertedColor = createLayeredColorUsingColorOnly(containedColor),
+  uncontainedInvertedColorDisabled,
+}: FlexColorFactoryInput): FlexColor => ({
   activated: createColorGamut({
-    containedColor: config.containedColor,
-    containedColorFactory: config.containedColorFactory,
-    containedInvertedColor: config.containedInvertedColor,
+    containedColor,
+    containedColorFactory,
+    containedInvertedColor,
     interactionType: InteractionType.Activated,
-    uncontainedColor: config.uncontainedColor,
-    uncontainedColorFactory: config.uncontainedColorFactory,
-    uncontainedInvertedColor: config.uncontainedInvertedColor,
+    uncontainedColor,
+    uncontainedColorFactory,
+    uncontainedInvertedColor,
   }),
   disabled: {
-    contained: config.containedColorDisabled,
-    containedInverted: config.containedInvertedColorDisabled,
-    uncontained: config.uncontainedColorDisabled,
-    uncontainedInverted: config.uncontainedInvertedColorDisabled,
+    contained: containedColorDisabled,
+    containedInverted: containedInvertedColorDisabled,
+    uncontained: uncontainedColorDisabled,
+    uncontainedInverted: uncontainedInvertedColorDisabled,
   },
   enabled: createColorGamut({
-    containedColor: config.containedColor,
-    containedColorFactory: config.containedColorFactory,
-    containedInvertedColor: config.containedInvertedColor,
+    containedColor,
+    containedColorFactory,
+    containedInvertedColor,
     interactionType: InteractionType.Enabled,
-    uncontainedColor: config.uncontainedColor,
-    uncontainedColorFactory: config.uncontainedColorFactory,
-    uncontainedInvertedColor: config.uncontainedInvertedColor,
+    uncontainedColor,
+    uncontainedColorFactory,
+    uncontainedInvertedColor,
   }),
   focused: createColorGamut({
-    containedColor: config.containedColor,
-    containedColorFactory: config.containedColorFactory,
-    containedInvertedColor: config.containedInvertedColor,
+    containedColor,
+    containedColorFactory,
+    containedInvertedColor,
     interactionType: InteractionType.Focused,
-    uncontainedColor: config.uncontainedColor,
-    uncontainedColorFactory: config.uncontainedColorFactory,
-    uncontainedInvertedColor: config.uncontainedInvertedColor,
+    uncontainedColor,
+    uncontainedColorFactory,
+    uncontainedInvertedColor,
   }),
   hovered: createColorGamut({
-    containedColor: config.containedColor,
-    containedColorFactory: config.containedColorFactory,
-    containedInvertedColor: config.containedInvertedColor,
+    containedColor,
+    containedColorFactory,
+    containedInvertedColor,
     interactionType: InteractionType.Hovered,
-    uncontainedColor: config.uncontainedColor,
-    uncontainedColorFactory: config.uncontainedColorFactory,
-    uncontainedInvertedColor: config.uncontainedInvertedColor,
+    uncontainedColor,
+    uncontainedColorFactory,
+    uncontainedInvertedColor,
   }),
   pressed: createColorGamut({
-    containedColor: config.containedColor,
-    containedColorFactory: config.containedColorFactory,
-    containedInvertedColor: config.containedInvertedColor,
+    containedColor,
+    containedColorFactory,
+    containedInvertedColor,
     interactionType: InteractionType.Pressed,
-    uncontainedColor: config.uncontainedColor,
-    uncontainedColorFactory: config.uncontainedColorFactory,
-    uncontainedInvertedColor: config.uncontainedInvertedColor,
+    uncontainedColor,
+    uncontainedColorFactory,
+    uncontainedInvertedColor,
   }),
 });

--- a/packages/core/src/color/index.ts
+++ b/packages/core/src/color/index.ts
@@ -6,8 +6,10 @@
  */
 
 export * from './ColorGamut';
+export * from './ColorGamutFactoryInput';
 export * from './ColorGetterInput';
 export * from './ColorProps';
+export * from './createColorGamut';
 export * from './createFlexColor';
 export * from './createLayeredColorUsingColorOnly';
 export * from './createLayeredColorUsingOnColorOnly';


### PR DESCRIPTION
- Add default arguments to `core/src/color/createFlexColor.ts`.
- Add new `core-md/src/color/createMdFlexColor.ts` with default arguments related to Material Design implementation of colors.
- Refactor all Material Design colors to use new `createMdFlexColor.ts`.