### PR TITLE
fix(ripple) fix ripple position when tapping over a children element

### DIFF
--- a/packages/ripple-elevation-md/src/AnimatedRippleElevationView.tsx
+++ b/packages/ripple-elevation-md/src/AnimatedRippleElevationView.tsx
@@ -8,6 +8,7 @@
 import {
   InteractionStateProps,
   SurfacePropsBase,
+  useTimeout,
   ViewTheme,
 } from '@reflex-ui/core';
 import {
@@ -16,10 +17,17 @@ import {
 } from '@reflex-ui/elevation-md';
 import {
   AnimatedRippleViewProps,
+  ElementMeasure,
   useRippleAnimation,
 } from '@reflex-ui/ripple-md';
-import React, { useState } from 'react';
-import { LayoutChangeEvent, View } from 'react-native';
+import React, {
+  forwardRef,
+  MutableRefObject,
+  Ref,
+  useRef,
+  useState,
+} from 'react';
+import { View } from 'react-native';
 import { animated } from 'react-spring/native';
 
 export interface AnimatedRippleElevationViewProps<ComponentProps>
@@ -28,54 +36,83 @@ export interface AnimatedRippleElevationViewProps<ComponentProps>
 
 const AnimatedView = animated(View);
 
-export const AnimatedRippleElevationView = <
-  ComponentProps extends SurfacePropsBase<ComponentProps, Theme> &
-    InteractionStateProps,
-  Theme extends ViewTheme<ComponentProps>
->(
-  props: AnimatedRippleElevationViewProps<ComponentProps>,
-): JSX.Element => {
-  const { children, complexComponentProps, onLayout, ...otherProps } = props;
-  const { elevation = 0, interactionState } = complexComponentProps;
+export const AnimatedRippleElevationView = forwardRef(
+  <
+    ComponentProps extends SurfacePropsBase<ComponentProps, Theme> &
+      InteractionStateProps,
+    Theme extends ViewTheme<ComponentProps>
+  >(
+    props: AnimatedRippleElevationViewProps<ComponentProps>,
+    ref: Ref<View>,
+  ): JSX.Element => {
+    const { children, complexComponentProps, onLayout, ...otherProps } = props;
+    const { elevation = 0, interactionState } = complexComponentProps;
 
-  const [containerSize, setContainerSize] = useState({ height: 0, width: 0 });
+    let viewRef: Ref<View> = useRef(null);
+    if (ref) viewRef = ref;
+    const [elementMeasure, setElementMeasure] = useState<ElementMeasure>({
+      height: 0,
+      pageX: 0,
+      pageY: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    });
 
-  const onLayoutChanged = (event: LayoutChangeEvent) => {
-    const { height, width } = event.nativeEvent.layout;
-    setContainerSize({ height, width });
-    if (onLayout) onLayout(event);
-  };
+    /*
+     * In my tests if we don't use a timeout, i.e., we just use
+     * a useEffect(), measure() returns zero for all values.
+     * When testing with 10 miliseconds I could also see
+     * zero returned a few times. 50 miliseconds worked for all tests.
+     */
+    useTimeout(() => {
+      if (
+        viewRef === undefined ||
+        viewRef === null ||
+        (viewRef as MutableRefObject<View>).current === undefined ||
+        (viewRef as MutableRefObject<View>).current === null
+      ) {
+        return;
+      }
+      (viewRef as MutableRefObject<View>).current.measure(
+        (x, y, width, height, pageX, pageY) =>
+          setElementMeasure({ height, pageX, pageY, width, x, y }),
+      );
+    }, 50);
 
-  const { rippleContainerStyle, rippleMotionStyle } = useRippleAnimation({
-    color: props.getRippleColor(props.complexComponentProps),
-    containerSize,
-    containerStyle: props.style,
-    interactionState,
-  });
+    const { rippleContainerStyle, rippleMotionStyle } = useRippleAnimation({
+      color: props.getRippleColor(props.complexComponentProps),
+      containerStyle: props.style,
+      elementMeasure,
+      interactionState,
+    });
 
-  const {
-    elevationContainerStyle,
-    elevationMotionStyle,
-  } = useElevationAnimation({
-    containerStyle: props.style,
-    elevation,
-    interactionState,
-  });
+    const {
+      elevationContainerStyle,
+      elevationMotionStyle,
+    } = useElevationAnimation({
+      containerStyle: props.style,
+      elevation,
+      interactionState,
+    });
 
-  const renderedAnimatedElevationView = (
+    const renderedAnimatedElevationView = (
+      // @ts-ignore
+      <AnimatedView style={elevationMotionStyle} />
+    );
     // @ts-ignore
-    <AnimatedView style={elevationMotionStyle} />
-  );
-  // @ts-ignore
-  const renderedAnimatedRippleView = <AnimatedView style={rippleMotionStyle} />;
+    const renderedAnimatedRippleView = (
+      <AnimatedView style={rippleMotionStyle} />
+    );
 
-  return (
-    <View {...otherProps} onLayout={onLayoutChanged}>
-      <View style={elevationContainerStyle}>
-        {renderedAnimatedElevationView}
-        <View style={rippleContainerStyle}>{renderedAnimatedRippleView}</View>
+    return (
+      <View key="rippleElevationSurface" {...otherProps} ref={viewRef}>
+        <View key="rippleElevationContainer" style={elevationContainerStyle}>
+          {renderedAnimatedElevationView}
+          <View style={rippleContainerStyle}>{renderedAnimatedRippleView}</View>
+        </View>
+        {children}
       </View>
-      {children}
-    </View>
-  );
-};
+    );
+  },
+);

--- a/packages/ripple-elevation-md/src/createAnimatedRippleElevationView.tsx
+++ b/packages/ripple-elevation-md/src/createAnimatedRippleElevationView.tsx
@@ -32,6 +32,16 @@ export const createAnimatedRippleElevationView = <
       <AnimatedRippleElevationView
         {...otherProps}
         complexComponentProps={{ ...complexComponentProps, elevation }}
+        /*
+         * I don't know why this error is hapenning, and how to fix it.
+         * It needs further investigation, and there's a chance that this is
+         * a TypeScript issue.
+         */
+        // @ts-ignore Type 'RippleColorGetter<Props>' is not assignable to type
+        // 'RippleColorGetter<SurfacePropsBase<any, any>
+        // & InteractionStateProps>'.
+        // Type 'SurfacePropsBase<any, any> & InteractionStateProps'
+        // is not assignable to type 'Props'.ts(2322)
         getRippleColor={getRippleColor}
       />
     );

--- a/packages/ripple-md/src/AnimatedRippleView.tsx
+++ b/packages/ripple-md/src/AnimatedRippleView.tsx
@@ -9,11 +9,19 @@ import {
   BuiltInSimpleComponentProps,
   InteractionStateProps,
   SurfacePropsBase,
+  useTimeout,
 } from '@reflex-ui/core';
-import React, { useState } from 'react';
-import { LayoutChangeEvent, View, ViewProps } from 'react-native';
+import React, {
+  forwardRef,
+  MutableRefObject,
+  Ref,
+  useRef,
+  useState,
+} from 'react';
+import { View, ViewProps } from 'react-native';
 import { animated } from 'react-spring/native';
 
+import { ElementMeasure } from './ElementMeasure';
 import { useRippleAnimation } from './useRippleAnimation';
 
 export type RippleColorGetter<ComponentProps> = (
@@ -29,50 +37,77 @@ export interface AnimatedRippleViewProps<ComponentProps>
 
 const AnimatedView = animated(View);
 
-export const AnimatedRippleView = <
-  ComponentProps extends SurfacePropsBase<ComponentProps, Theme> &
-    InteractionStateProps,
-  Theme
->(
-  props: AnimatedRippleViewProps<ComponentProps>,
-): JSX.Element => {
-  const { children, complexComponentProps, onLayout, ...otherProps } = props;
-  const { interactionState } = complexComponentProps;
+export const AnimatedRippleView = forwardRef(
+  <
+    ComponentProps extends SurfacePropsBase<ComponentProps, Theme> &
+      InteractionStateProps,
+    Theme
+  >(
+    props: AnimatedRippleViewProps<ComponentProps>,
+    ref: Ref<View>,
+  ): JSX.Element => {
+    const { children, complexComponentProps, ...otherProps } = props;
+    const { interactionState } = complexComponentProps;
 
-  const [containerSize, setContainerSize] = useState({ height: 0, width: 0 });
+    let viewRef: Ref<View> = useRef(null);
+    if (ref) viewRef = ref;
+    const [elementMeasure, setElementMeasure] = useState<ElementMeasure>({
+      height: 0,
+      pageX: 0,
+      pageY: 0,
+      width: 0,
+      x: 0,
+      y: 0,
+    });
 
-  const onLayoutChanged = (event: LayoutChangeEvent) => {
-    const { height, width } = event.nativeEvent.layout;
-    setContainerSize({ height, width });
-    if (onLayout) onLayout(event);
-  };
+    /*
+     * In my tests if we don't use a timeout, i.e., we just use
+     * a useEffect(), measure() returns zero for all values.
+     * When testing with 10 miliseconds I could also see
+     * zero returned a few times. 50 miliseconds worked for all tests.
+     */
+    useTimeout(() => {
+      if (
+        viewRef === undefined ||
+        viewRef === null ||
+        (viewRef as MutableRefObject<View>).current === undefined ||
+        (viewRef as MutableRefObject<View>).current === null
+      ) {
+        return;
+      }
+      (viewRef as MutableRefObject<View>).current.measure(
+        (x, y, width, height, pageX, pageY) =>
+          setElementMeasure({ height, pageX, pageY, width, x, y }),
+      );
+    }, 50);
 
-  const { rippleContainerStyle, rippleMotionStyle } = useRippleAnimation({
-    color: props.getRippleColor(props.complexComponentProps),
-    containerSize,
-    containerStyle: props.style,
-    interactionState,
-  });
+    const { rippleContainerStyle, rippleMotionStyle } = useRippleAnimation({
+      color: props.getRippleColor(props.complexComponentProps),
+      containerStyle: props.style,
+      elementMeasure,
+      interactionState,
+    });
 
-  /*
-   * It seems that there's some type definition bug
-   * in react-spring causing the error below. See this link:
-   * github.com/react-spring/react-spring/issues/642#issuecomment-488072147
-   * Remove ts-ignore when that bug is fixed.
-   */
-  // @ts-ignore error TS2589: Type instantiation
-  // is excessively deep and possibly infinite.
-  const renderedAnimatedView = (
+    /*
+     * It seems that there's some type definition bug
+     * in react-spring causing the error below. See this link:
+     * github.com/react-spring/react-spring/issues/642#issuecomment-488072147
+     * Remove ts-ignore when that bug is fixed.
+     */
     // @ts-ignore error TS2589: Type instantiation
-    <AnimatedView key="rippleAnimation" style={rippleMotionStyle} />
-  );
+    // is excessively deep and possibly infinite.
+    const renderedAnimatedView = (
+      // @ts-ignore error TS2589: Type instantiation
+      <AnimatedView key="rippleAnimation" style={rippleMotionStyle} />
+    );
 
-  return (
-    <View key="rippleSurface" {...otherProps} onLayout={onLayoutChanged}>
-      <View key="rippleContainer" style={rippleContainerStyle}>
-        {renderedAnimatedView}
+    return (
+      <View key="rippleSurface" {...otherProps} ref={viewRef}>
+        <View key="rippleContainer" style={rippleContainerStyle}>
+          {renderedAnimatedView}
+        </View>
+        {children}
       </View>
-      {children}
-    </View>
-  );
-};
+    );
+  },
+);

--- a/packages/ripple-md/src/ComponentRippleStylesFactoryInput.ts
+++ b/packages/ripple-md/src/ComponentRippleStylesFactoryInput.ts
@@ -8,11 +8,14 @@
 import { InteractionEvent } from '@reflex-ui/core';
 import { ViewStyle } from 'react-native';
 
+import { ElementMeasure } from './ElementMeasure';
+
 export interface ComponentRippleStylesFactoryInput {
   readonly color: string;
-  readonly height: number;
+  readonly elementMeasure: ElementMeasure;
+  // readonly height: number;
   readonly interactionEvent?: InteractionEvent;
   readonly maxDiameter?: number;
   readonly style: ViewStyle;
-  readonly width: number;
+  // readonly width: number;
 }

--- a/packages/ripple-md/src/ElementMeasure.ts
+++ b/packages/ripple-md/src/ElementMeasure.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export interface ElementMeasure {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly pageX: number;
+  readonly pageY: number;
+}

--- a/packages/ripple-md/src/createAnimatedRippleView.tsx
+++ b/packages/ripple-md/src/createAnimatedRippleView.tsx
@@ -23,5 +23,15 @@ export const createAnimatedRippleView = <
   function AnimatedRippleViewFactory(
     props: BuiltInSimpleComponentProps<Props>,
   ) {
+    /*
+     * I don't know why this error is hapenning, and how to fix it.
+     * It needs further investigation, and there's a chance that this is
+     * a TypeScript issue.
+     */
+    // @ts-ignore Type 'RippleColorGetter<Props>' is not assignable to type
+    // 'RippleColorGetter<SurfacePropsBase<any, any>
+    // & InteractionStateProps>'.
+    // Type 'SurfacePropsBase<any, any> & InteractionStateProps'
+    // is not assignable to type 'Props'.ts(2322)
     return <AnimatedRippleView {...props} getRippleColor={getRippleColor} />;
   };

--- a/packages/ripple-md/src/createComponentRippleStyles.ts
+++ b/packages/ripple-md/src/createComponentRippleStyles.ts
@@ -15,19 +15,23 @@ import { RippleStyles } from './RippleStyles';
 
 export const createComponentRippleStyles = ({
   color,
-  height,
+  elementMeasure,
+  // height,
   interactionEvent,
   maxDiameter,
   style,
-  width,
-}: ComponentRippleStylesFactoryInput): RippleStyles => {
-  const interactionPosition = getInteractionPosition(interactionEvent);
+}: // width,
+ComponentRippleStylesFactoryInput): RippleStyles => {
+  const interactionPosition = getInteractionPosition(
+    elementMeasure,
+    interactionEvent,
+  );
   const diameter = calculateRippleDiameter({
-    height,
+    height: elementMeasure.height,
     maxDiameter,
     posX: interactionPosition.x,
     posY: interactionPosition.y,
-    width,
+    width: elementMeasure.width,
   });
 
   const position = calculateRipplePosition({ diameter, interactionPosition });

--- a/packages/ripple-md/src/getInteractionPosition.ts
+++ b/packages/ripple-md/src/getInteractionPosition.ts
@@ -7,9 +7,12 @@
 
 import { InteractionEvent } from '@reflex-ui/core';
 import { GestureResponderEvent } from 'react-native';
+
+import { ElementMeasure } from './ElementMeasure';
 import { Position2D } from './Position2D';
 
 export const getInteractionPosition = (
+  elementMeasure: ElementMeasure,
   interactionEvent?: InteractionEvent,
 ): Position2D => {
   let x = 0;
@@ -19,8 +22,12 @@ export const getInteractionPosition = (
     interactionEvent &&
     (interactionEvent as GestureResponderEvent).nativeEvent
   ) {
-    x = (interactionEvent as GestureResponderEvent).nativeEvent.locationX;
-    y = (interactionEvent as GestureResponderEvent).nativeEvent.locationY;
+    x =
+      (interactionEvent as GestureResponderEvent).nativeEvent.pageX -
+      elementMeasure.pageX;
+    y =
+      (interactionEvent as GestureResponderEvent).nativeEvent.pageY -
+      elementMeasure.pageY;
   }
 
   return { x, y };

--- a/packages/ripple-md/src/index.ts
+++ b/packages/ripple-md/src/index.ts
@@ -12,6 +12,7 @@ export * from './ComponentRippleStylesFactoryInput';
 export * from './createAnimatedRippleView';
 export * from './createComponentRippleStyles';
 export * from './createRippleStyles';
+export * from './ElementMeasure';
 export * from './getInteractionPosition';
 export * from './getSurfaceRippleColor';
 export * from './Position2D';

--- a/packages/ripple-md/src/useRippleAnimation.ts
+++ b/packages/ripple-md/src/useRippleAnimation.ts
@@ -11,12 +11,14 @@ import { StyleProp, StyleSheet, ViewStyle } from 'react-native';
 import { useSpring, UseSpringProps } from 'react-spring/native';
 
 import { createComponentRippleStyles } from './createComponentRippleStyles';
+import { ElementMeasure } from './ElementMeasure';
 import { RippleStyles } from './RippleStyles';
 
 export interface RippleAnimationInput {
   readonly color: string;
-  readonly containerSize: { height: number; width: number };
+  // readonly containerSize: { height: number; width: number };
   readonly containerStyle: StyleProp<ViewStyle>;
+  readonly elementMeasure: ElementMeasure;
   readonly interactionState: InteractionState;
   readonly maxDiameter?: number;
 }
@@ -28,8 +30,9 @@ export interface RippleAnimationOutput {
 
 export const useRippleAnimation = ({
   color,
-  containerSize,
+  // containerSize,
   containerStyle,
+  elementMeasure,
   interactionState,
   maxDiameter,
 }: RippleAnimationInput): RippleAnimationOutput => {
@@ -103,11 +106,12 @@ export const useRippleAnimation = ({
          */
         color,
         /**/
-        height: containerSize.height,
+        // height: containerSize.height,
+        elementMeasure,
         interactionEvent,
         maxDiameter,
         style: StyleSheet.flatten(containerStyle),
-        width: containerSize.width,
+        // width: containerSize.width,
       }),
     );
     setIsAnimatingPressIn(true);


### PR DESCRIPTION
React Native's `event.nativeEvent.locationX` / `locationY` is not always relative to the Touchable component (actually its root `<View>` child), but to the target element. Consider this example:

```jsx
<TouchableWithoutFeedback>
  <View>
    <Text>Hello</Text>
  </View>
</TouchableWithoutFeedback>
```

If we tap over `<View>` element, but not over `<Text>` content, everything works as expected, i.e., `nativeEvent.locationX` / `locationY` is relative to `<View>`. But when we tap over `<Text>` content, `nativeEvent.locationX` / `locationY` is relative to `<Text>`, which is relative to `<View>`. That causes an issue in this codebase that the ripple position should always be relative to `<View>`, not any of its children. If it's relative to any children, it looks off as its animation doesn't start from where we visually tap it.

That could be fixed by adding `pointerEvents: "box-only"` to `<View>`, but that'd break nested touchable components.

This PR fixes that issue by calculating the correct `locationX` / `locationY` position based on `nativeEvent.pageX` / `nativeEvent.pageY` of the target component (`<View>` or `<Text>` in this case) and the root `<View>` component.

Ref: https://github.com/facebook/react-native/issues/966#issuecomment-107232289