### PR TITLE
feat(core/transition) implement module & use in Modal, Backdrop & Sheet

### DIFF
--- a/apps/core-showcase/src/navigation/Navigation.ts
+++ b/apps/core-showcase/src/navigation/Navigation.ts
@@ -270,7 +270,7 @@ export const AppNavigation = () => {
     Navigation.setRoot({
       root: {
         component: {
-          name: SheetNavigation.modalSideSheet,
+          name: ModalNavigation.default,
         },
       },
     });

--- a/apps/core-showcase/src/screens/modal/ModalScreen.tsx
+++ b/apps/core-showcase/src/screens/modal/ModalScreen.tsx
@@ -91,6 +91,7 @@ export const getModalSurfaceTheme: ComponentThemeGetter<
     return {
       left,
       maxHeight,
+      opacity: props.isOpen ? 1 : 0,
       position: 'absolute',
       top,
       width,
@@ -101,12 +102,41 @@ export const getModalSurfaceTheme: ComponentThemeGetter<
 const MyModal = (props: ModalPropsOptional) => {
   const { palette } = usePalette();
 
+  const modalWillOpen = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('ModalScreen().modalWillOpen()');
+  }, []);
+
+  const modalDidOpen = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('ModalScreen().modalDidOpen()');
+  }, []);
+
+  const modalWillClose = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('ModalScreen().modalWillClose()');
+  }, []);
+
+  const modalDidClose = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('ModalScreen().modalDidClose()');
+  }, []);
+
   return (
-    <Modal {...props}>
+    <Modal
+      componentDidClose={modalDidClose}
+      componentDidOpen={modalDidOpen}
+      componentWillClose={modalWillClose}
+      componentWillOpen={modalWillOpen}
+      isOpenCloseTransitionAnimated
+      {...props}
+    >
       <Surface
         enableOnLayout
+        elevation={24}
         flexWrap={FlexWrap.Nowrap}
         getPatchTheme={getModalSurfaceTheme}
+        isOpen={props.isOpen}
         padding={Size.M}
         pointerEvents="auto"
       >

--- a/apps/core-showcase/src/screens/sheet/CoplanarSideSheetStartScreen.tsx
+++ b/apps/core-showcase/src/screens/sheet/CoplanarSideSheetStartScreen.tsx
@@ -33,7 +33,7 @@ import { Filters } from '../../ui';
 
 const onButtonPress = () => {
   // tslint:disable-next-line:no-console
-  console.log('SurfaceScreen().onButtonPress()');
+  console.log('CoplanarSideSheetStartScreen().onButtonPress()');
 };
 
 const loremCopy = [
@@ -68,15 +68,35 @@ const CoplanarSideSheetStartScreen: React.SFC<{}> = (): JSX.Element => {
 
   const openCoplanarSideSheet = useCallback(() => {
     // tslint:disable-next-line:no-console
-    console.log('SheetScreen().openCoplanarSideSheet()');
+    console.log('CoplanarSideSheetStartScreen().openCoplanarSideSheet()');
     setIsShowingCoplanarSideSheet(true);
   }, [isShowingCoplanarSideSheet]);
 
   const closeCoplanarSideSheet = useCallback(() => {
     // tslint:disable-next-line:no-console
-    console.log('SheetScreen().closeCoplanarSideSheet()');
+    console.log('CoplanarSideSheetStartScreen().closeCoplanarSideSheet()');
     setIsShowingCoplanarSideSheet(false);
   }, [isShowingCoplanarSideSheet]);
+
+  const coplanarSideSheetWillOpen = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('CoplanarSideSheetStartScreen().coplanarSideSheetWillOpen()');
+  }, []);
+
+  const coplanarSideSheetDidOpen = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('CoplanarSideSheetStartScreen().coplanarSideSheetDidOpen()');
+  }, []);
+
+  const coplanarSideSheetWillClose = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('CoplanarSideSheetStartScreen().coplanarSideSheetWillClose()');
+  }, []);
+
+  const coplanarSideSheetDidClose = useCallback(() => {
+    // tslint:disable-next-line:no-console
+    console.log('CoplanarSideSheetStartScreen().coplanarSideSheetDidClose()');
+  }, []);
 
   return (
     <Screen>
@@ -91,7 +111,12 @@ const CoplanarSideSheetStartScreen: React.SFC<{}> = (): JSX.Element => {
       </AppBar>
       <Row flex={1}>
         <CoplanarSideSheet
+          componentDidClose={coplanarSideSheetDidClose}
+          componentDidOpen={coplanarSideSheetDidOpen}
+          componentWillClose={coplanarSideSheetWillClose}
+          componentWillOpen={coplanarSideSheetWillOpen}
           isOpen={isShowingCoplanarSideSheet}
+          isOpenCloseTransitionAnimated
           paddingEnd={0}
           paddingTop={Size.XS}
           variant={CoplanarSideSheetVariant.Start}

--- a/packages/core-md/src/color/colors/black/mdBlackBackdrop.ts
+++ b/packages/core-md/src/color/colors/black/mdBlackBackdrop.ts
@@ -21,7 +21,7 @@ import { white } from '../white/white';
  */
 
 const blackBackdropLayeredColor: LayeredColor = {
-  color: 'rgba(0, 0, 0, 0.7)',
+  color: 'rgba(0, 0, 0, 0.5)',
   onColor: white,
 };
 

--- a/packages/core-md/src/components/animatedMaterialDesignTheme.ts
+++ b/packages/core-md/src/components/animatedMaterialDesignTheme.ts
@@ -12,7 +12,7 @@ import { avatarImageTheme } from './avatar-image/theme';
 // tslint:disable-next-line:max-line-length
 import { animatedAvatarOverlaySurfaceTheme } from './avatar-overlay-surface/animatedTheme';
 import { avatarTheme } from './avatar/theme';
-import { backdropTheme } from './backdrop/theme';
+import { animatedBackdropTheme } from './backdrop/animatedTheme';
 import { animatedButtonTheme } from './button/animatedTheme';
 import { imageTheme } from './image/theme';
 import { animatedListItemTheme } from './list-item/animatedTheme';
@@ -35,7 +35,7 @@ export const animatedMaterialDesignTheme: ComponentsTheme = {
   avatar: avatarTheme,
   avatarImage: avatarImageTheme,
   avatarOverlaySurface: animatedAvatarOverlaySurfaceTheme,
-  backdrop: backdropTheme,
+  backdrop: animatedBackdropTheme,
   button: animatedButtonTheme,
   coplanarSideSheet: animatedCoplanarSideSheetVariantsTheme,
   image: imageTheme,

--- a/packages/core-md/src/components/backdrop/animatedTheme.ts
+++ b/packages/core-md/src/components/backdrop/animatedTheme.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  BackdropTheme,
+  SurfaceProps,
+  SurfaceTheme,
+  ViewStyleGetter,
+} from '@reflex-ui/core';
+import { UseSpringProps } from 'react-spring';
+
+import { createAnimatedOpenCloseTransitionSurface } from '../surface';
+import { getBackdropSurfaceProps, getBackdropSurfaceStyle } from './theme';
+
+const animationConfig = { clamp: true, tension: 220, friction: 12 };
+
+const closeAnimationProps: UseSpringProps = {
+  config: animationConfig,
+  to: { opacity: 0 },
+};
+
+const openAnimationProps: UseSpringProps = {
+  config: { ...animationConfig },
+  from: { opacity: 0 },
+  to: { opacity: 1 },
+};
+
+const AnimatedComponent = createAnimatedOpenCloseTransitionSurface<
+  SurfaceProps,
+  SurfaceTheme
+>({
+  closeAnimationProps,
+  openAnimationProps,
+});
+
+const getAnimatedComponent = () => AnimatedComponent;
+
+export const getAnimatedBackdropSurfaceStyle: ViewStyleGetter<
+  SurfaceProps
+> = props => ({
+  ...getBackdropSurfaceStyle(props),
+  opacity: 0,
+});
+
+export const animatedBackdropTheme: BackdropTheme = {
+  surface: () => ({
+    getComponent: getAnimatedComponent,
+    getProps: getBackdropSurfaceProps,
+    getStyle: getAnimatedBackdropSurfaceStyle,
+  }),
+};

--- a/packages/core-md/src/components/sheet/coplanar-side-sheet/animatedTheme.ts
+++ b/packages/core-md/src/components/sheet/coplanar-side-sheet/animatedTheme.ts
@@ -15,7 +15,7 @@ import {
 import { ComponentType } from 'react';
 import { StyleSheet } from 'react-native';
 
-import { createAnimatedOpeningSurfacePusher } from '../../surface';
+import { createAnimatedOpenCloseTransitionSurfacePusher } from '../../surface';
 
 import {
   getCoplanarSideSheetEndSurfaceStyle,
@@ -66,7 +66,7 @@ const createStartComponent = (maxWidth: number | string = 0) => {
   };
 
   currentStartMaxWidth = maxWidth;
-  currentStartComponent = createAnimatedOpeningSurfacePusher<
+  currentStartComponent = createAnimatedOpenCloseTransitionSurfacePusher<
     CoplanarSideSheetProps,
     CoplanarSideSheetTheme
   >({
@@ -112,7 +112,7 @@ const createEndComponent = (maxWidth: number | string = 0) => {
   };
 
   currentEndMaxWidth = maxWidth;
-  currentEndComponent = createAnimatedOpeningSurfacePusher<
+  currentEndComponent = createAnimatedOpenCloseTransitionSurfacePusher<
     CoplanarSideSheetProps,
     CoplanarSideSheetTheme
   >({

--- a/packages/core-md/src/components/surface/AnimatedOpenCloseTransitionSurface.tsx
+++ b/packages/core-md/src/components/surface/AnimatedOpenCloseTransitionSurface.tsx
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  BuiltInSimpleComponentProps,
+  moveTransformPropsToTransformArray,
+  SurfacePropsBase,
+} from '@reflex-ui/core';
+import React, { forwardRef, Ref, useCallback, useRef } from 'react';
+import { StyleSheet, View, ViewProps } from 'react-native';
+import { animated, useSpring, UseSpringProps } from 'react-spring/native';
+
+export interface AnimatedOpenCloseTransitionSurfaceProps<ComponentProps>
+  extends BuiltInSimpleComponentProps<ComponentProps>,
+    ViewProps {
+  readonly children?: React.ReactNode;
+  readonly closeAnimationProps?: UseSpringProps;
+  readonly openAnimationProps?: UseSpringProps;
+}
+
+const AnimatedView = animated(View);
+
+export const AnimatedOpenCloseTransitionSurface = forwardRef(
+  <ComponentProps extends SurfacePropsBase<ComponentProps, Theme>, Theme>(
+    props: AnimatedOpenCloseTransitionSurfaceProps<ComponentProps>,
+    ref: Ref<View>,
+  ): JSX.Element => {
+    const { children, complexComponentProps, ...otherProps } = props;
+    const {
+      componentDidClose,
+      componentDidOpen,
+      isClosing,
+      isOpen,
+      isOpening,
+    } = complexComponentProps;
+
+    const onOpenRest = useCallback(() => {
+      if (componentDidOpen !== undefined && isOpening) {
+        componentDidOpen(complexComponentProps);
+      }
+    }, [complexComponentProps]);
+
+    const onCloseRest = useCallback(() => {
+      if (componentDidClose !== undefined && isClosing) {
+        componentDidClose(complexComponentProps);
+      }
+    }, [complexComponentProps]);
+
+    /*
+     * Since we cannot have hooks inside conditions (useSpring in this case),
+     * and we cannot pass undefined to useSpring,
+     * a simple solution is to introduce this emptyAnimationProps
+     * object when we don't have surface animation props.
+     */
+    const emptyAnimationProps = {
+      config: { clamp: true, tension: 220, friction: 16 },
+    };
+    /**/
+
+    let openAnimationProps = props.openAnimationProps;
+    if (openAnimationProps === undefined) {
+      openAnimationProps = emptyAnimationProps;
+    } else if (openAnimationProps.onRest === undefined) {
+      openAnimationProps = {
+        ...openAnimationProps,
+        ...(componentDidOpen !== undefined && { onRest: onOpenRest }),
+      };
+    }
+
+    let closeAnimationProps = props.closeAnimationProps;
+    if (closeAnimationProps === undefined) {
+      closeAnimationProps = emptyAnimationProps;
+    } else if (closeAnimationProps.onRest === undefined) {
+      closeAnimationProps = {
+        ...closeAnimationProps,
+        ...(componentDidClose !== undefined && { onRest: onCloseRest }),
+      };
+    }
+
+    let viewRef: Ref<View> = useRef(null);
+    if (ref) viewRef = ref;
+
+    const animationProps = useSpring(
+      isOpen ? openAnimationProps : closeAnimationProps,
+    );
+
+    // tslint:disable-next-line:max-line-length
+    const animationPropsWithTransformHandled = moveTransformPropsToTransformArray(
+      animationProps,
+    );
+
+    const finalStyle = {
+      ...StyleSheet.flatten(props.style),
+      ...animationPropsWithTransformHandled,
+    };
+
+    return (
+      // @ts-ignore Type instantiation is excessively
+      // deep and possibly infinite.ts(2589)
+      <AnimatedView
+        key="AnimatedOpenCloseTransitionSurfaceView"
+        {...otherProps}
+        ref={viewRef}
+        style={finalStyle}
+      >
+        {children}
+      </AnimatedView>
+    );
+  },
+);

--- a/packages/core-md/src/components/surface/createAnimatedOpenCloseTransitionSurface.tsx
+++ b/packages/core-md/src/components/surface/createAnimatedOpenCloseTransitionSurface.tsx
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { BuiltInSimpleComponentProps, SurfacePropsBase } from '@reflex-ui/core';
+import React from 'react';
+import { UseSpringProps } from 'react-spring/native';
+
+// tslint:disable-next-line:max-line-length
+import { AnimatedOpenCloseTransitionSurface } from './AnimatedOpenCloseTransitionSurface';
+
+export interface AnimatedOpenCloseTransitionSurfaceFactoryInput {
+  readonly closeAnimationProps?: UseSpringProps;
+  readonly openAnimationProps?: UseSpringProps;
+}
+
+export const createAnimatedOpenCloseTransitionSurface = <
+  Props extends SurfacePropsBase<Props, Theme>,
+  Theme
+>({
+  closeAnimationProps,
+  openAnimationProps,
+}: AnimatedOpenCloseTransitionSurfaceFactoryInput) =>
+  function AnimatedOpenCloseTransitionSurfaceFactory(
+    props: BuiltInSimpleComponentProps<Props>,
+  ) {
+    return (
+      <AnimatedOpenCloseTransitionSurface
+        closeAnimationProps={closeAnimationProps}
+        openAnimationProps={openAnimationProps}
+        {...props}
+      />
+    );
+  };

--- a/packages/core-md/src/components/surface/createAnimatedOpenCloseTransitionSurfacePusher.tsx
+++ b/packages/core-md/src/components/surface/createAnimatedOpenCloseTransitionSurfacePusher.tsx
@@ -9,26 +9,27 @@ import { BuiltInSimpleComponentProps, SurfacePropsBase } from '@reflex-ui/core';
 import React from 'react';
 import { UseSpringProps } from 'react-spring/native';
 
-import { AnimatedOpeningSurfacePusher } from './AnimatedOpeningSurfacePusher';
+// tslint:disable-next-line:max-line-length
+import { AnimatedOpenCloseTransitionSurfacePusher } from './AnimatedOpenCloseTransitionSurfacePusher';
 
-export interface AnimatedOpeningSurfacePusherFactoryInput {
+export interface AnimatedOpenCloseTransitionSurfacePusherFactoryInput {
   readonly closePusherAnimationProps: UseSpringProps;
   readonly closeSurfaceAnimationProps?: UseSpringProps;
   readonly openPusherAnimationProps: UseSpringProps;
   readonly openSurfaceAnimationProps?: UseSpringProps;
 }
 
-export const createAnimatedOpeningSurfacePusher = <
+export const createAnimatedOpenCloseTransitionSurfacePusher = <
   Props extends SurfacePropsBase<Props, Theme>,
   Theme
 >(
-  input: AnimatedOpeningSurfacePusherFactoryInput,
+  input: AnimatedOpenCloseTransitionSurfacePusherFactoryInput,
 ) =>
-  function AnimatedOpeningSurfacePusherFactory(
+  function AnimatedOpenCloseTransitionSurfacePusherFactory(
     props: BuiltInSimpleComponentProps<Props>,
   ) {
     return (
-      <AnimatedOpeningSurfacePusher
+      <AnimatedOpenCloseTransitionSurfacePusher
         closePusherAnimationProps={input.closePusherAnimationProps}
         closeSurfaceAnimationProps={input.closeSurfaceAnimationProps}
         openPusherAnimationProps={input.openPusherAnimationProps}

--- a/packages/core-md/src/components/surface/index.ts
+++ b/packages/core-md/src/components/surface/index.ts
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './AnimatedOpeningSurfacePusher';
+export * from './AnimatedOpenCloseTransitionSurface';
+export * from './AnimatedOpenCloseTransitionSurfacePusher';
 export * from './animatedTheme';
-export * from './createAnimatedOpeningSurfacePusher';
+export * from './createAnimatedOpenCloseTransitionSurface';
+export * from './createAnimatedOpenCloseTransitionSurfacePusher';
 export * from './theme';

--- a/packages/core/src/components/backdrop/Backdrop.tsx
+++ b/packages/core/src/components/backdrop/Backdrop.tsx
@@ -10,6 +10,7 @@ import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../errors';
 import { useOnLayout } from '../../responsiveness/useOnLayout';
+import { useOpenCloseTransition } from '../../transition';
 import { filterOutTouchableWithoutFeedbackProps } from '../../utils/props';
 import { useComponentsTheme } from '../ComponentsTheme';
 import { processComponent } from '../processComponent';
@@ -65,6 +66,7 @@ let Backdrop: React.ComponentType<BackdropPropsOptional> = forwardRef(
 
     let newProps: BackdropProps = useDefaultBackdropProps(props, theme);
     newProps = { ...newProps, ...useOnLayout(newProps) };
+    newProps = { ...newProps, ...useOpenCloseTransition(newProps) };
     newProps = processComponentProps(newProps);
     newProps = processThemeAndStyleProps(newProps, newProps.theme.touchable);
 

--- a/packages/core/src/components/modal/ModalProps.ts
+++ b/packages/core/src/components/modal/ModalProps.ts
@@ -10,8 +10,12 @@ import { GestureResponderEvent } from 'react-native';
 import { ColorProps } from '../../color/ColorProps';
 import { DimensionsProps } from '../../responsiveness/DimensionsProps';
 import { OnLayoutProps } from '../../responsiveness/OnLayoutProps';
+import { OpenCloseTransitionProps } from '../../transition';
 import { ComponentChildrenProps } from '../ComponentChildrenProps';
-import { ComponentThemeProps } from '../ComponentThemeProps';
+import {
+  ComponentThemeProps,
+  ComponentThemePropsOptional,
+} from '../ComponentThemeProps';
 import { ModalTheme } from './ModalTheme';
 
 export interface ModalPropsBase
@@ -19,13 +23,19 @@ export interface ModalPropsBase
     DimensionsProps,
     OnLayoutProps {
   readonly displayBackdrop?: boolean;
-  readonly isOpen?: boolean;
   readonly onBackdropPress?: (event: GestureResponderEvent) => void;
 }
+
+export type ModalPropsBaseOptional = Partial<ModalPropsBase>;
 
 export interface ModalProps
   extends ComponentChildrenProps<ModalProps>,
     ComponentThemeProps<ModalProps, ModalTheme>,
-    ModalPropsBase {}
+    ModalPropsBase,
+    OpenCloseTransitionProps<ModalProps> {}
 
-export type ModalPropsOptional = Partial<ModalProps>;
+export interface ModalPropsOptional
+  extends ComponentChildrenProps<ModalProps>,
+    ComponentThemePropsOptional<ModalProps, ModalTheme>,
+    ModalPropsBaseOptional,
+    OpenCloseTransitionProps<ModalProps> {}

--- a/packages/core/src/components/sheet/coplanar-side-sheet/CoplanarSideSheet.tsx
+++ b/packages/core/src/components/sheet/coplanar-side-sheet/CoplanarSideSheet.tsx
@@ -10,6 +10,7 @@ import { View } from 'react-native';
 
 import { MissingComponentThemeError } from '../../../errors';
 import { useOnLayout } from '../../../responsiveness/useOnLayout';
+import { useOpenCloseTransition } from '../../../transition';
 import { useComponentsTheme } from '../../ComponentsTheme';
 import { processComponent } from '../../processComponent';
 import { processComponentProps } from '../../processComponentProps';
@@ -52,6 +53,7 @@ let CoplanarSideSheet: React.ComponentType<
     theme,
   );
   newProps = { ...newProps, ...useOnLayout(newProps) };
+  newProps = { ...newProps, ...useOpenCloseTransition(newProps) };
   newProps = processComponentProps(newProps);
   newProps = processThemeAndStyleProps(newProps, newProps.theme);
 

--- a/packages/core/src/components/view/RfxViewProps.ts
+++ b/packages/core/src/components/view/RfxViewProps.ts
@@ -15,6 +15,7 @@ import { OnLayoutProps } from '../../responsiveness/OnLayoutProps';
 import { SizingPropsOptional } from '../../sizing/SizingProps';
 import { MarginProps } from '../../spacing/MarginProps';
 import { PaddingProps } from '../../spacing/PaddingProps';
+import { OpenCloseTransitionProps } from '../../transition';
 import { ComponentChildrenProps } from '../ComponentChildrenProps';
 import { ComponentThemeProps } from '../ComponentThemeProps';
 import { RfxViewTheme } from './RfxViewTheme';
@@ -41,10 +42,10 @@ export interface RfxViewPropsBase<Props, Theme>
     FlexboxProps,
     MarginProps,
     OnLayoutProps,
+    OpenCloseTransitionProps<Props>,
     PaddingProps,
     SizingPropsOptional,
     ViewProps {
-  readonly isOpen?: boolean;
   readonly ref?: Ref<View>;
   readonly shouldProvideColor?: boolean;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,5 +14,6 @@ export * from './interaction';
 export * from './responsiveness';
 export * from './sizing';
 export * from './spacing';
+export * from './transition';
 export * from './utils';
 export * from './utils-ts';

--- a/packages/core/src/transition/OpenCloseTransitionProps.ts
+++ b/packages/core/src/transition/OpenCloseTransitionProps.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export interface OpenCloseTransitionProps<ComponentProps> {
+  readonly isOpenCloseTransitionAnimated?: boolean;
+  readonly isClosing?: boolean;
+  readonly isOpen?: boolean;
+  readonly shouldCallOpenCloseCallbacks?: boolean;
+  readonly isOpening?: boolean;
+  readonly componentDidClose?: (props: ComponentProps) => void;
+  readonly componentDidOpen?: (props: ComponentProps) => void;
+  readonly componentWillClose?: (props: ComponentProps) => void;
+  readonly componentWillOpen?: (props: ComponentProps) => void;
+}

--- a/packages/core/src/transition/filterOutOpenCloseTransitionProps.ts
+++ b/packages/core/src/transition/filterOutOpenCloseTransitionProps.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { OpenCloseTransitionProps } from './OpenCloseTransitionProps';
+
+export const filterOutOpenCloseTransitionProps = <
+  Props extends OpenCloseTransitionProps<Props>
+>(
+  props: Props,
+): Pick<Props, Exclude<keyof Props, keyof OpenCloseTransitionProps<Props>>> => {
+  const {
+    componentDidClose,
+    componentDidOpen,
+    componentWillClose,
+    componentWillOpen,
+    isClosing,
+    isOpen,
+    isOpenCloseTransitionAnimated,
+    isOpening,
+    shouldCallOpenCloseCallbacks,
+    ...otherProps
+  } = props;
+
+  return otherProps;
+};

--- a/packages/core/src/transition/index.ts
+++ b/packages/core/src/transition/index.ts
@@ -5,5 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export * from './animatedTheme';
-export * from './theme';
+export * from './filterOutOpenCloseTransitionProps';
+export * from './OpenCloseTransitionProps';
+export * from './useOpenCloseTransition';

--- a/packages/core/src/transition/useOpenCloseTransition.ts
+++ b/packages/core/src/transition/useOpenCloseTransition.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Flavio Silva https://flsilva.com
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { OpenCloseTransitionProps } from './OpenCloseTransitionProps';
+
+export const useOpenCloseTransition = <
+  Props extends OpenCloseTransitionProps<Props>
+>(
+  props: Props,
+): OpenCloseTransitionProps<Props> => {
+  const hasAnyCallback = useCallback(
+    () =>
+      props.componentDidClose !== undefined ||
+      props.componentDidOpen !== undefined ||
+      props.componentWillClose !== undefined ||
+      props.componentWillOpen !== undefined,
+    [
+      props.componentDidClose,
+      props.componentDidOpen,
+      props.componentWillClose,
+      props.componentWillOpen,
+    ],
+  );
+
+  /*
+   * We define a local shouldCallOpenCloseCallbacks that uses
+   * props.shouldCallOpenCloseCallbacks if !== undefined,
+   * or automatically set it to true if hasAnyCallback()
+   * (end users expecting callbacks to be called).
+   */
+  const [
+    shouldCallOpenCloseCallbacks,
+    setShouldCallOpenCloseCallbacks,
+  ] = useState(() =>
+    props.shouldCallOpenCloseCallbacks !== undefined
+      ? props.shouldCallOpenCloseCallbacks
+      : hasAnyCallback(),
+  );
+  if (
+    props.shouldCallOpenCloseCallbacks !== undefined &&
+    props.shouldCallOpenCloseCallbacks !== shouldCallOpenCloseCallbacks
+  ) {
+    setShouldCallOpenCloseCallbacks(props.shouldCallOpenCloseCallbacks);
+  }
+  /**/
+
+  const [isOpening, setIsOpening] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [prevIsOpen, setPrevIsOpen] = useState<boolean | undefined>(false);
+
+  const componentWillOpen = useCallback(
+    (componentProps: Props) => {
+      setIsOpening(true);
+      if (props.componentWillOpen !== undefined) {
+        props.componentWillOpen(componentProps);
+      }
+    },
+    [props],
+  );
+
+  const componentDidOpen = useCallback(
+    (componentProps: Props) => {
+      setIsOpening(false);
+      if (props.componentDidOpen !== undefined) {
+        props.componentDidOpen(componentProps);
+      }
+    },
+    [props],
+  );
+
+  const componentWillClose = useCallback(
+    (componentProps: Props) => {
+      setIsClosing(true);
+      if (props.componentWillClose !== undefined) {
+        props.componentWillClose(componentProps);
+      }
+    },
+    [props],
+  );
+
+  const componentDidClose = useCallback(
+    (componentProps: Props) => {
+      setIsClosing(false);
+      if (props.componentDidClose !== undefined) {
+        props.componentDidClose(componentProps);
+      }
+    },
+    [props],
+  );
+
+  /*
+   * We want componentWillOpen() and componentDidOpen() to be called
+   * after componentDidMount() (and its hooks version),
+   * so we put that logic into useEffect().
+   */
+  useEffect(() => {
+    if (
+      shouldCallOpenCloseCallbacks &&
+      props.isOpen &&
+      !props.isOpening &&
+      !prevIsOpen
+    ) {
+      componentWillOpen(props);
+      if (!props.isOpenCloseTransitionAnimated) componentDidOpen(props);
+    } else if (
+      shouldCallOpenCloseCallbacks &&
+      !props.isOpen &&
+      !props.isClosing &&
+      prevIsOpen
+    ) {
+      componentWillClose(props);
+      if (!props.isOpenCloseTransitionAnimated) componentDidClose(props);
+    }
+
+    if (props.isOpen !== prevIsOpen) {
+      setPrevIsOpen(props.isOpen);
+    }
+  }, [
+    shouldCallOpenCloseCallbacks,
+    prevIsOpen,
+    props.isClosing,
+    props.isOpen,
+    props.isOpening,
+  ]);
+  /**/
+
+  return {
+    componentDidClose,
+    componentDidOpen,
+    componentWillClose,
+    componentWillOpen,
+    isClosing,
+    isOpen: prevIsOpen,
+    isOpening,
+    shouldCallOpenCloseCallbacks,
+  };
+};


### PR DESCRIPTION
- Add support for open and close transition and callbacks (`isOpen`, `isOpening`, `isClosing`, `componentWillOpen`, `componentDidOpen`, `componentWillClose`, `componentDidClose`).
  Motivation: more flexibility when implementing transition animations, supporting the ability to take action on critical events. That's also required in order to allow components like `<Modal>` to lazily render their children while supporting animations, by avoiding rendering their children when they're not open (omitting from React's component tree and platforms' native nodes).
- Implement an animated theme for `<Backdrop>`.
- Implement reusable `<AnimatedOpenCloseTransitionSurface>` to make it easier to implement open and close transition animations (used by `<Backdrop>`s animated theme).
- `<Backdrop>`, `<Modal>`, and `<CoplanarSideSheet>` now uses `useOpenCloseTransition`. `<Modal>` lazily renders its children, including support for animated transitions, i.e., it waits `<Backdrop>` transition to stop rendering their children (by returning `null`).
